### PR TITLE
Restoring core html

### DIFF
--- a/2014/core.html
+++ b/2014/core.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-
-<!-- COMPATIBILITY -->
 <!--[if lt IE 7]> <html class="no-js no-svg lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
 <!--[if IE 7]><html class="no-js no-svg lt-ie9 lt-ie8" lang="en"> <![endif]-->
 <!--[if IE 8]><html class="no-js no-svg lt-ie9" lang="en"> <![endif]-->


### PR DESCRIPTION
I've made a couple small changes to the markup that are still awaiting corresponding CSS changes. These should only appear when tools are disclosed. I'm going back to calling the file core.html in keeping with the current WSU template. I'd love to use something more in keeping with the Spine metaphor, but we'll see if I come up with anything. Reminds me of how much I like the naming of Wordpress' "Codex".
