### PR TITLE
[PR] Add repository data to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "wsu-spine",
   "version": "0.5.0",
   "build_version": "0.5",
+  "repository" : {
+	  "type" : "git",
+	  "url" : "http://github.com/washingtonstateuniversity/wsu-spine.git"
+  },
   "file": "spine",
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
This fixes the display of a warning when running `npm install` to update dependencies. There is no harm in not having a repository URL, but warnings are annoying.
