### PR TITLE
Adding the csslint Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,12 @@ module.exports = function(grunt) {
 			}
 		},
 
+		csslint: {
+			spine: {
+				src: ['<%= config.build %>/spine.css']
+			}
+		},
+
 		cssmin: {
 			combine: {
 				files: {
@@ -438,6 +444,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-cssmin');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-sass');
+	grunt.loadNpmTasks('grunt-contrib-csslint');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-env');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-csslint": "^0.2.0",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-sass": "^0.7.3",


### PR DESCRIPTION
Introducing CSSLint for cleaner CSS! We JSHint, so why not CSSLint, too?

I didn't add it as part of the build, because there is no `force` option yet. Watch gruntjs/grunt-contrib-csslint#21.
