### PR TITLE
Correcting Google Plus class name

### DIFF
--- a/styles/sass/_spine-styles.scss
+++ b/styles/sass/_spine-styles.scss
@@ -762,9 +762,9 @@ html.lt-ie9 #spine footer {
 			a:before { content: "H"; }
 			a:hover { color: $github-blue !important; }
 			}
-		.gplus-channel {
+		.googleplus-channel {
 			a:before { content: "G"; }
-			a:hover { color: $gplus-orange !important; }
+			a:hover { color: $googleplus-orange !important; }
 			}
 		.instagram-channel {
 			a:before { content: "I"; }

--- a/styles/sass/vars/_colors.scss
+++ b/styles/sass/vars/_colors.scss
@@ -88,7 +88,7 @@ $twitter-light: #e1e8ed;
 $youtube-red: #cc181e;
 $linkedin-blue: #007bb6;
 $pinterest-red: #cb2027;
-$gplus-orange: #dd4b39;
+$googleplus-orange: #dd4b39;
 $github-blue: #4183c4;
 $flickr-pink: #ff0084;
 $tumblr-blue: #34526f;
@@ -97,8 +97,3 @@ $tumblr-blue: #32506d;
 $instagram-blue: #517fa4;
 $vine-green: #00bf8f;
 $vimeo-green: #aad450;
-
-
-
-
-


### PR DESCRIPTION
[`spine.html`](https://github.com/washingtonstateuniversity/WSU-spine/blob/4724d6f7010ffe1fef2d733c4c9ca7b3609d4a97/spine.html#L145) specifies that the Google Plus social channel class should be `.googleplus-channel`, rather than `.gplus-channel`.
