### PR TITLE
[PR] Correct ../vars/global import

### DIFF
--- a/styles/sass/skeleton/_pad.scss
+++ b/styles/sass/skeleton/_pad.scss
@@ -1,4 +1,4 @@
-@import 'vars/global';
+@import '../vars/global';
 
 @mixin pad {
 

--- a/styles/sass/skeleton/_spacing.scss
+++ b/styles/sass/skeleton/_spacing.scss
@@ -1,4 +1,4 @@
-@import 'vars/global';
+@import '../vars/global';
 
 @mixin spacers {
 


### PR DESCRIPTION
`grunt prod` and `grunt dev` are failing because of an incorrect location for the global vars
