### PR TITLE
hotfix on the external link auto add class

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -454,7 +454,7 @@
 				return this.hostname && this.hostname !== window.location.hostname;
 			}).addClass("external");*/
 
-			$(".spine-navigation a:not([href*='"+window.location.hostname+"'])").addClass("external");
+			$(".spine-navigation a[href^='http']:not([href*='"+window.location.hostname+"'])").addClass("external");
 
 		},
 

--- a/spine.html
+++ b/spine.html
@@ -31,7 +31,7 @@
 	<link type="text/html" rel="help" href="http://brand.wsu.edu">
 
 	<!-- BASE URL -->
-	<base href="/develop/" />
+	<base href="file:///D:/_GIT/WSU-MAIN/WSU-spine/build/" />
 
 </head>
 

--- a/spine.min.html
+++ b/spine.min.html
@@ -31,7 +31,7 @@
 	<link type="text/html" rel="help" href="http://brand.wsu.edu">
 
 	<!-- BASE URL -->
-	<base href="/develop/" />
+	<base href="file:///D:/_GIT/WSU-MAIN/WSU-spine/build/" />
 
 </head>
 


### PR DESCRIPTION
added [href^='http'] to the selector so that we first have to even see
that it's a full url before we check to see that it's not the same
hostname
