### PR TITLE
Correlate js size classes with hard breaks

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -136,11 +136,11 @@
 				ele_class="size-xlarge size-gt-small size-gt-smallish size-gt-medium size-gt-large";
 			} else if(current_width >= 990) {
 				ele_class="size-large size-lt-xlarge size-gt-small size-gt-smallish size-gt-medium";
-			} else if(current_width < 990 && current_width >= 792) {
+			} else if((current_width >= 694 && current_width < 792) && ($("#binder").is(".fixed"))) {
+				ele_class="size-smallish size-lt-medium size-lt-large size-lt-xlarge size-gt-small";
+			} else if(current_width < 990 && current_width >= 694) {
 				ele_class="size-medium size-lt-xlarge size-lt-large size-gt-smallish size-gt-small";
-			} else if(current_width >= 694 && current_width < 792) {
-				ele_class="size-small size-smallish size-lt-medium size-lt-large size-lt-xlarge size-gt-small";
-			} else if(current_width < 792) {
+			} else if(current_width < 694) {
 				ele_class="size-small size-lt-smallish size-lt-medium size-lt-large size-lt-xlarge";
 			} else if(current_width < 396) {
 				ele_class="size-small size-lt-small size-lt-smallish size-lt-medium size-lt-large size-lt-xlarge";


### PR DESCRIPTION
Size small now refers consistently to stacked columns after the last
hard break in all behaviors instead of using the last “fixed” break for
fluid and hybrid.
