### PR TITLE
[PR] Introduce a CHANGELOG.md document to the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# WSU Spine Changelog
+
+## 1.2.0 (in progress)
+
+### Framework Changes
+
+* Remove `.gutless` synonym, which was likely never used.
+* Update orange accent hex per brand changes.
+* Add social icons for Google Plus, Instagram, Vine, Vimeo, GitHub, and Flickr
+* Add `margin-left` and `margin-right` layouts to `gutter`
+* Correct campus zipcode to 99164
+
+### Development Changes
+
+* Break `gruntfile.js` into smaller options files for better management.
+* Introduce CONTRIBUTING document explaning development workflow.
+* Remove most compiled files from the repository.
+* Refactor build process to support multiple versions in production.
+* Refactor development workflow to use `develop` branch.
+
+## 1.1.0 (August 20, 2014)
+
+
+## 1.0.0 (June 30, 2014)
+
+* Initial launch of the Spine Framework.


### PR DESCRIPTION
I've attempted to fill out the 1.2.0 changelog a bit as we'll be
shipping that later in the week. 1.0.0 was our first official
tagged release, so we don't have versioned data before that.

Leaving 1.1.0 blank in the hopes we add some nice stuff there at
some point.

See #144
