### PR TITLE
[PR] Update all develop branch references to version 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "wsu-spine",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"latest_stable": "1",
-	"build_version": "develop",
+	"build_version": "1",
 	"build_location": "",
 	"repository": {
 		"type": "git",

--- a/spine.html
+++ b/spine.html
@@ -13,7 +13,7 @@
 	<link rel="shortcut icon" href="http://repo.wsu.edu/spine/1/favicon.ico" />
 
 	<!-- STYLESHEETS -->
-	<link href="https://repo.wsu.edu/spine/develop/spine.min.css" rel="stylesheet" type="text/css" />
+	<link href="https://repo.wsu.edu/spine/1/spine.min.css" rel="stylesheet" type="text/css" />
 	<!-- Your custom stylesheets here -->
 	<!-- RESPOND -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes">
@@ -21,7 +21,7 @@
 	<!-- SCRIPTS -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-	<script src="https://repo.wsu.edu/spine/develop/spine.min.js"></script>
+	<script src="https://repo.wsu.edu/spine/1/spine.min.js"></script>
 	<!-- COMPATIBILITY -->
 	<!--[if lt IE 9]><script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 	<noscript><style>#spine .spine-sitenav ul ul li { display: block !important; }</style></noscript>
@@ -31,7 +31,7 @@
 	<link type="text/html" rel="help" href="http://brand.wsu.edu">
 
 	<!-- BASE URL -->
-	<base href="/develop/" />
+	<base href="/1/" />
 
 </head>
 

--- a/spine.min.html
+++ b/spine.min.html
@@ -13,7 +13,7 @@
 	<link rel="shortcut icon" href="http://repo.wsu.edu/spine/1/favicon.ico" />
 
 	<!-- STYLESHEETS -->
-	<link href="https://repo.wsu.edu/spine/develop/spine.min.css" rel="stylesheet" type="text/css" />
+	<link href="https://repo.wsu.edu/spine/1/spine.min.css" rel="stylesheet" type="text/css" />
 	<!-- Your custom stylesheets here -->
 	<!-- RESPOND -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes">
@@ -21,7 +21,7 @@
 	<!-- SCRIPTS -->
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-	<script src="https://repo.wsu.edu/spine/develop/spine.min.js"></script>
+	<script src="https://repo.wsu.edu/spine/1/spine.min.js"></script>
 	<!-- COMPATIBILITY -->
 	<!--[if lt IE 9]><script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 	<noscript><style>#spine .spine-sitenav ul ul li { display: block !important; }</style></noscript>
@@ -31,7 +31,7 @@
 	<link type="text/html" rel="help" href="http://brand.wsu.edu">
 
 	<!-- BASE URL -->
-	<base href="/develop/" />
+	<base href="/1/" />
 
 </head>
 

--- a/styles/opensans.css
+++ b/styles/opensans.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: "OpenSans";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans,
@@ -10,8 +10,8 @@
 
 @font-face {
   font-family: "OpenSans-Bold";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Bold.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Bold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Bold.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Bold.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Bold.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Bold.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Bold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Bold.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Bold.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Bold.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-bold,
@@ -20,8 +20,8 @@
 
 @font-face {
   font-family: "OpenSans-BoldItalic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-BoldItalic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-BoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-BoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-BoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-BoldItalic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-BoldItalic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-BoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-BoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-BoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-BoldItalic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-bolditalic,
@@ -30,8 +30,8 @@
 
 @font-face {
   font-family: "OpenSans-CondBold";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondBold.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondBold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondBold.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondBold.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondBold.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondBold.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondBold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondBold.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondBold.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondBold.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-condbold,
@@ -40,8 +40,8 @@
 
 @font-face {
   font-family: "OpenSans-CondLight";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLight.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLight.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLight.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLight.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLight.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLight.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLight.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLight.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLight.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLight.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-condlight,
@@ -50,8 +50,8 @@
 
 @font-face {
   font-family: "OpenSans-CondLightItalic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLightItalic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLightItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLightItalic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLightItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-CondLightItalic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLightItalic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLightItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLightItalic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLightItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-CondLightItalic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-condlightitalic,
@@ -60,8 +60,8 @@
 
 @font-face {
   font-family: "OpenSans-ExtraBold";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBold.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBold.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBold.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBold.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBold.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBold.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBold.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBold.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-extrabold,
@@ -70,8 +70,8 @@
 
 @font-face {
   font-family: "OpenSans-ExtraBoldItalic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBoldItalic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-ExtraBoldItalic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBoldItalic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-ExtraBoldItalic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-extrabolditalic,
@@ -80,8 +80,8 @@
 
 @font-face {
   font-family: "OpenSans-Italic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Italic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Italic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Italic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Italic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Italic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Italic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Italic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Italic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Italic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Italic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-italic,
@@ -90,8 +90,8 @@
 
 @font-face {
   font-family: "OpenSans-Light";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Light.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Light.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Light.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Light.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Light.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Light.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Light.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Light.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Light.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Light.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-light,
@@ -100,8 +100,8 @@
 
 @font-face {
   font-family: "OpenSans-LightItalic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-LightItalic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-LightItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-LightItalic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-LightItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-LightItalic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-LightItalic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-LightItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-LightItalic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-LightItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-LightItalic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-lightitalic,
@@ -110,8 +110,8 @@
 
 @font-face {
   font-family: "OpenSans-Semibold";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Semibold.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Semibold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Semibold.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Semibold.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-Semibold.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Semibold.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-Semibold.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Semibold.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Semibold.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-Semibold.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-semibold,
@@ -120,8 +120,8 @@
 
 @font-face {
   font-family: "OpenSans-SemiBoldItalic";
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-SemiBoldItalic.eot");
-  src: url("//repo.wsu.edu/spine/develop/fonts/OpenSans-SemiBoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-SemiBoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-SemiBoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/develop/fonts/OpenSans-SemiBoldItalic.svg#OpenSans") format("svg");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-SemiBoldItalic.eot");
+  src: url("//repo.wsu.edu/spine/1/fonts/OpenSans-SemiBoldItalic.eot?#iefix") format("embedded-opentype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-SemiBoldItalic.woff") format("woff"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-SemiBoldItalic.ttf") format("truetype"), url("//repo.wsu.edu/spine/1/fonts/OpenSans-SemiBoldItalic.svg#OpenSans") format("svg");
   font-weight: normal;
   font-style: normal; }
 .opensans-semibolditalic,

--- a/styles/sass/vars/_global.scss
+++ b/styles/sass/vars/_global.scss
@@ -25,7 +25,7 @@ $counter: (
 	23: twentythree,
 	24: twentyfour
 	);
-	
+
 // Breaks
 $breaks: (
 	594: 'small',
@@ -37,7 +37,7 @@ $breaks: (
 	1782: 'max-1782',
 	1980: 'max-1980'
 	);
-	
+
 $sizes: (
 	594: 'small',
 	791: 'smallish',
@@ -76,11 +76,11 @@ $campuses: $pullman,$spokane,$vancouver,$tricities,$globalcampus,$extension;
 	}
 
 // locality acts as a base URL for assets. This must be updated when tagging a new release.
-// HTTPS is forced to avoid issues with file:// and because we're better of planning ahead.
-$locality: 'https://repo.wsu.edu/spine/develop';
+// HTTPS is forced to avoid issues with file:// and because we're better off planning ahead.
+$locality: 'https://repo.wsu.edu/spine/1';
 // font_domain accomplishes the same thing, but does not force HTTPS to avoid CORs issues when
 // a page is displayed via HTTP
-$font_domain: '//repo.wsu.edu/spine/develop';
+$font_domain: '//repo.wsu.edu/spine/1';
 
 @mixin signatures($directionality,$path) {
 
@@ -184,9 +184,9 @@ $font_domain: '//repo.wsu.edu/spine/develop';
 		}
 
 	}
-	
+
 @mixin header-colors {
-	
+
 	#binder #spine {
 		header { background-color: white; }
 		@each $spine-color, $color in $spine-colors {


### PR DESCRIPTION
Right before merging to `master` tomorrow, we'll want to update all versioning to reference the major version number so that assets are not loaded from the `develop` branch.

After the merge to `master`, we can update `develop` to revert. Tedious, but it works for now.
