### PR TITLE
[PR] Hide the #shelve button by default for non-mobile views

### DIFF
--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -112,6 +112,10 @@
 
 /* ### Spine Menu Button (Shelve and Unshelve) */
 
+button#shelve {
+  display:none;
+	}
+
 .shelved button#shelve,.unshelved button#shelve {
 	height: 50px;
 	width: 100px;


### PR DESCRIPTION
This may actually be more visible because of the switch from `append` to `prepend` in b6e72fbdc44d

It should be safe to `display: none;` by default and then allow the `.shelved` and `.unshelved` rules to apply `display: block;` when a mobile view is displayed.

Fixes #179
