### PR TITLE
[PR] Remove duplicate charset declaration

### DIFF
--- a/styles/sass/_skeleton.scss
+++ b/styles/sass/_skeleton.scss
@@ -9,8 +9,6 @@
 @import 'skeleton/margin';
 @import 'skeleton/unbind';
 
-@charset "UTF-8";
-
 /* # Skeleton */
 
 /* ## RESET */


### PR DESCRIPTION
The charset declaration added in e5433cda6d0b is a duplicate of the one on the first line of the skeleton file.
