### PR TITLE
[PR] Use dest as src when sassing and autoprefixing

### DIFF
--- a/tasks/options/autoprefixer.js
+++ b/tasks/options/autoprefixer.js
@@ -3,7 +3,7 @@ module.exports = {
 		browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1', 'ie 8', 'ie 9','ie 10']
 	},
 	front_styles: {
-		src: 'tmp/css/spine.css',
+		src: '<%= config.build %>/spine.css',
 		dest: '<%= config.build %>/spine.css'
 	},
 }

--- a/tasks/options/sass.js
+++ b/tasks/options/sass.js
@@ -1,7 +1,7 @@
 module.exports = {
 	dev: {
 		files: [
-			{ src: 'styles/sass/spine.scss', dest: 'tmp/css/spine.css' },
+			{ src: 'styles/sass/spine.scss', dest: '<%= config.build %>/spine.css' },
 			{ src: 'styles/sass/opensans.scss', dest: '<%= config.build %>/styles/opensans.css' }
 		]
 	}


### PR DESCRIPTION
This removes the need for a `tmp/` directory in the working directory
