### PR TITLE
Make each layout aware of different behaviors

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -147,11 +147,12 @@
 		},
 		// Label #jacket with current window size
 		sizing: function (jacket) {
-			var current_width,ele_class,px_width;
-			jacket=jacket||$("#jacket");
-			current_width = $(window).width();
 			
-			var size_small,size_intermediate,size_medium,size_large,size_xlarge;
+			var current_width,ele_class,px_width,size_small,size_intermediate,size_medium,size_large,size_xlarge;
+
+            jacket=jacket||$("#jacket");
+            current_width = $(window).width();
+			
 			size_small = "size-small size-lt-intermediate size-lt-smallish size-lt-medium size-lt-large size-lt-xlarge";
 			size_intermediate = "size-intermediate size-smallish size-lt-medium size-lt-large size-lt-xlarge size-gt-small";
 			size_medium = "size-medium size-lt-xlarge size-lt-large size-gt-intermediate size-gt-smallish size-gt-small";
@@ -167,24 +168,16 @@
 				ele_class=size_large;
 			} else if((current_width < 990) && current_width >= 792 ) {
 				px_width="size-lt-990";
-				if ($("#binder").is(".fluid")) {
-					ele_class=size_large;
-				} else {
-					ele_class=size_medium;
-				}
+				ele_class= $("#binder").is(".fluid") ? size_large : size_medium;
 			} else if(current_width < 792 && current_width >= 694) {
 				px_width="size-lt-792";
-				if ($("#binder").is(".fixed")) {
-					ele_class=size_intermediate;
-				} else {
-					ele_class=size_medium;
-				}
+				ele_class= $("#binder").is(".fixed") ? size_intermediate : size_medium;
 			} else if(current_width < 694 && current_width >= 396) {
 				ele_class=size_small;
 			} else if(current_width < 396) {
 				ele_class="size-small size-lt-small size-lt-intermediate size-lt-smallish size-lt-medium size-lt-large size-lt-xlarge";
 			}
-			jacket.stripClass("size-").addClass(ele_class).addClass(px_width);
+			jacket.stripClass("size-").addClass(ele_class+" "+px_width);
 		},
 		// Equalize Columns
 		equalizing: function () {


### PR DESCRIPTION
Layouts transition between large, medium, and small at different points
depending on selected responsive behavior. “Large” is default
appearance. At “Medium”, the spine collapses and becomes a header
spine. At “Small”, most columns stack and become full width. We are
targeting these basic layouts rather than specific viewport widths. To
be able to target differences between behaviors, a pixel width
designation is also present where there is divergence between
behaviors. This should account for all scenarios.
