### PR TITLE
[PR] Use the global `spineoptions` object when starting the Spine Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## 1.2.3 (In progress)
 
+### Framework Changes
+
 * Add further support for `.size-intermediate`.
-* Add support for override of default `spineoptions` object. Please take care when overriding these options as the structure is not final.
+* Add more explicit support for the override of default `spineoptions` object with `window.spineoptions`.
+
+### Temporary Changes
+
+* Options for `share_text`, `twitter_handle`, and `twitter_text` are now available for override.
+    * This naming is not finalized and will be changed without deprecation notice.
+    * Please leave a note on [#230](https://github.com/washingtonstateuniversity/WSU-spine/issues/230) to express interest in these options.
 
 ## 1.2.2 (December 22, 2014)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # WSU Spine Changelog
 
-## 1.3.0 (In progress)
+## 1.2.3 (In progress)
+
+* Add further support for `.size-intermediate`.
+* Add support for override of default `spineoptions` object. Please take care when overriding these options as the structure is not final.
 
 ## 1.2.2 (December 22, 2014)
 

--- a/scripts/spine.js
+++ b/scripts/spine.js
@@ -2,7 +2,7 @@
 	"use strict";
 	$(document).ready(function(){
 		$("html").removeClass("no-js").addClass("js");
-		var spineoptions=spineoptions||{};
+		var spineoptions=window.spineoptions||{};
 		$.spine(spineoptions);
 	});
 })(jQuery);

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -25,13 +25,6 @@
 		 * https://github.com/washingtonstateuniversity/WSU-spine/issues/230
 		 */
 		social_options:{
-			provider:"WSU_share",
-			script_url:"//repo.wsu.edu/wsu_share/1/",
-			channels:[
-				"facebook",
-				"twitter",
-				"Pintrest"
-			],
 			share_text:"You should know ...",
 			twitter_text:"You should know...",
 			twitter_handle:"wsupullman"

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -16,12 +16,13 @@
 		},
 		/**
 		 * These default options can be overridden with an object before
-		 * the Spine framework is started.
+		 * the Spine framework is started and with `$('body').spine( spineoptions )`.
 		 *
-		 * NOTE: The structure of these social options is subject to change and
-		 * will be deprecated in a future release. Please communicate with the WSU
-		 * Web Communication team (web.wsu.edu) when using these so that we can
-		 * aid in any transition in the future.
+		 * NOTE: The structure of these social options **will** change and could be
+		 * deprecated in a future release. Please communicate via the WSU Spine repository
+		 * when using these so that we can reach out before a transition in the future.
+		 *
+		 * https://github.com/washingtonstateuniversity/WSU-spine/issues/230
 		 */
 		social_options:{
 			provider:"WSU_share",

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -22,23 +22,25 @@
 				"twitter",
 				"Pintrest"
 			],
-			share_text:"You should know ..."
+			share_text:"You should know ...",
+			twitter_handle:"wsupullman"
 		},
 		social_globals: {
 			share_block: $("#wsu-share")
 		},
 		social_create: function(){
-			var self, share_block, share_text, current_url, wsu_actions, sharehtml;
+			var self, share_block, share_text, current_url, wsu_actions, sharehtml, twitter_handle;
 			self=this;//hold to preserve scope
 			share_block = self._get_globals("share_block").refresh();
 			if (!share_block.length) {
 				share_text = encodeURIComponent(this.social_options.share_text);
+				twitter_handle = encodeURIComponent(this.social_options.twitter_handle);
 				current_url = self._get_globals("current_url");
 				wsu_actions = self._get_globals("wsu_actions").refresh();
 				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'> \
 									<ul> \
 										<li class='by-facebook'><a href='http://www.facebook.com/sharer/sharer.php?u="+current_url+"'>Facebook</a></li> \
-										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+share_text+"&url="+current_url+"&via=wsupullman' target='_blank'>Twitter</a></li> \
+										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+share_text+"&url="+current_url+"&via="+twitter_handle+"' target='_blank'>Twitter</a></li> \
 										<li class='by-email'><a href='mailto:?subject="+share_text+"&body="+current_url+"'>Email</a></li> \
 									</ul> \
 									</section>";

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -14,6 +14,15 @@
 			this._set_globals(this.social_globals);
 			this.social_create();
 		},
+		/**
+		 * These default options can be overridden with an object before
+		 * the Spine framework is started.
+		 *
+		 * NOTE: The structure of these social options is subject to change and
+		 * will be deprecated in a future release. Please communicate with the WSU
+		 * Web Communication team (web.wsu.edu) when using these so that we can
+		 * aid in any transition in the future.
+		 */
 		social_options:{
 			provider:"WSU_share",
 			script_url:"//repo.wsu.edu/wsu_share/1/",

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -23,24 +23,26 @@
 				"Pintrest"
 			],
 			share_text:"You should know ...",
+			twitter_text:"You should know...",
 			twitter_handle:"wsupullman"
 		},
 		social_globals: {
 			share_block: $("#wsu-share")
 		},
 		social_create: function(){
-			var self, share_block, share_text, current_url, wsu_actions, sharehtml, twitter_handle;
+			var self, share_block, share_text, current_url, wsu_actions, sharehtml, twitter_text, twitter_handle;
 			self=this;//hold to preserve scope
 			share_block = self._get_globals("share_block").refresh();
 			if (!share_block.length) {
 				share_text = encodeURIComponent(this.social_options.share_text);
+				twitter_text = encodeURIComponent(this.social_options.twitter_text);
 				twitter_handle = encodeURIComponent(this.social_options.twitter_handle);
 				current_url = self._get_globals("current_url");
 				wsu_actions = self._get_globals("wsu_actions").refresh();
 				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'> \
 									<ul> \
 										<li class='by-facebook'><a href='http://www.facebook.com/sharer/sharer.php?u="+current_url+"'>Facebook</a></li> \
-										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+share_text+"&url="+current_url+"&via="+twitter_handle+"' target='_blank'>Twitter</a></li> \
+										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+twitter_text+"&url="+current_url+"&via="+twitter_handle+"' target='_blank'>Twitter</a></li> \
 										<li class='by-email'><a href='mailto:?subject="+share_text+"&body="+current_url+"'>Email</a></li> \
 									</ul> \
 									</section>";

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -50,7 +50,7 @@
 				wsu_actions = self._get_globals("wsu_actions").refresh();
 				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'> \
 									<ul> \
-										<li class='by-facebook'><a href='http://www.facebook.com/sharer/sharer.php?u="+current_url+"'>Facebook</a></li> \
+										<li class='by-facebook'><a href='https://www.facebook.com/sharer/sharer.php?u="+current_url+"'>Facebook</a></li> \
 										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+twitter_text+"&url="+current_url+"&via="+twitter_handle+"' target='_blank'>Twitter</a></li> \
 										<li class='by-email'><a href='mailto:?subject="+share_text+"&body="+current_url+"'>Email</a></li> \
 									</ul> \


### PR DESCRIPTION
In the current state, `spineoptions` cannot be filled by an object on the outside. The check for an existing `spineoptions` will always result in an empty object.

This uses `window.spineoptions` to use any existing data that the document is trying to provide. Pages can now override defaults by creating their own `spineoptions` object in the global space.

Also added a warning about possible changes to option names. We'll need to make these more structured in the future so that they scale properly.