### PR TITLE
[PR] Set advanced as false for cssmin to disable property merging

### DIFF
--- a/tasks/options/cssmin.js
+++ b/tasks/options/cssmin.js
@@ -1,4 +1,7 @@
 module.exports = {
+	options: {
+		advanced: false
+	},
 	combine: {
 		files: {
 			// Hmmm, in reverse order (see http://gruntjs.com/configuring-tasks#files-object-format)


### PR DESCRIPTION
This configuration is passed to css-clean by cssmin and prevents duplicate properties from being merged.