### PR TITLE
[PR] Reset standard view properly when print view is cancelled

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -477,6 +477,7 @@
 				$("html").toggleClass("print");
 				$(".shelved").removeClass("shelved").addClass("unshelved");
 				$(".print-controls").remove();
+				$(window).trigger("resize");
 			}
 
 			function print(e) {

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -475,6 +475,7 @@
 
 			function print_cancel() {
 				$("html").toggleClass("print");
+				$(".shelved").removeClass("shelved").addClass("unshelved");
 				$(".print-controls").remove();
 			}
 


### PR DESCRIPTION
* When the print icon is clicked, `.shelved` is added to the `#spine` to help orient the WSU mark at the top of the page similar to the mobile nav. It should be reversed to `.unshelved` when cancel is clicked on this screen.
* When the print icon is clicked, a resize event fires that assigns a different static width to `<main>`. This should also fire when the print view is cancelled so that `<main>` receives its proper width once again.