### PR TITLE
Add foundation to signature style declarations

### DIFF
--- a/styles/sass/vars/_global.scss
+++ b/styles/sass/vars/_global.scss
@@ -72,9 +72,10 @@ $everett: everett;
 
 // Miscellaneous
 $campaign: campaign; /* Stretching the definition of campus. New term? */
+$foundation: foundation;
 
 $campuses: $pullman,$spokane,$vancouver,$tricities,$globalcampus,$extension,$hs,$hss;
-$signatures: $pullman,$spokane,$vancouver,$tricities,$globalcampus,$extension,$hs,$hss,$campaign;
+$signatures: $pullman,$spokane,$vancouver,$tricities,$globalcampus,$extension,$hs,$hss,$foundation,$campaign;
 
 // Typography
 @mixin serif {


### PR DESCRIPTION
I’m leaving the campaign signature style in there for now in the event that some sites
don’t get manually switched over immediately.