### PR TITLE
[PR] Setup navigation scrolling for Android devices

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -104,8 +104,8 @@
 
 			self.setup_nav();
 
-			if ($.is_iOS()) {
-				$("html").addClass("ios");
+			if ( $.is_iOS() || $.is_Android() ) {
+				$( "html" ).addClass( "ios" );
 				self.setup_nav_scroll();
 			}
 


### PR DESCRIPTION
Add the `#scroll` element to Android devices so that the navigation scrolls properly.

This may not be a long term solution, as some things are still quirky, but it gives users access to the content. We'll want to revisit the Spine behavior on mobile in general at some point in the future.

Fixes #235.