### PR TITLE
[PR] Adjust mobile behavior, reduce some of the Javascript used in mobile

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -297,7 +297,7 @@
 			$("header button").on("click",function(e) {
 				e.preventDefault();
 				spine.toggleClass("unshelved shelved");
-				$( "html" ).addClass( "spine-mobile-nav" );
+				$( "html" ).toggleClass( "spine-mobile-nav" );
 			});
 
 			// Close the mobile Spine navigation when a click occurs outside of the Spine.

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -337,16 +337,18 @@
 				});
 			}
 
-			// Add skimming
-			$(document).scroll(function() {
-				var top;
-				top = $(document).scrollTop();
-				if ( top > 148 ) {
-					$("#spine").addClass("skimmed");
-				} else {
-					$("#spine").removeClass("skimmed");
-				}
-			});
+			// Apply the `.skimmed` class to the Spine on non mobile views after 148px.
+			if ( ! $.is_iOS() && !$.is_Android() ) {
+				$( document ).scroll( function() {
+					var top;
+					top = $( document ).scrollTop();
+					if ( top > 148 ) {
+						$( "#spine" ).addClass( "skimmed" );
+					} else {
+						$( "#spine" ).removeClass( "skimmed" );
+					}
+				} );
+			}
 		},
 
 		/**

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -305,37 +305,32 @@
 				}
 			});
 
+			// Fixed/Sticky Horizontal Header
+			$( document ).on( "scroll touchmove", function() {
+				self.apply_nav_func( self );
+			} );
 
-			if ($(".ios .hybrid .unshelved").length <= 0) {
-				// Fixed/Sticky Horizontal Header
-				$(document).on("scroll touchmove",function() {
-					self.apply_nav_func(self);
-				});
+			// Watch for DOM changes and resize the Spine to match.
+			$.observeDOM( glue , function() {
+				self.apply_nav_func( self );
+			} );
 
-				// Watch for DOM changes and resize the Spine to match.
-				$.observeDOM( glue , function(){
-					self.apply_nav_func(self);
-				});
+			$( document ).keydown( function( e ) {
+				if( e.which === 35 || e.which === 36 ) {
+					viewport_ht	= $( window ).height();
+					spine_ht	= spine[0].scrollHeight;
+					height_dif	= viewport_ht - spine_ht;
 
-				$(document).keydown(function(e) {
-					if(e.which === 35 || e.which === 36) {
-						viewport_ht		= $(window).height();
-						spine_ht		= spine[0].scrollHeight;
-						height_dif		= viewport_ht - spine_ht;
-						if (e.which === 35) {
-							positionLock = height_dif;
-						} else if (e.which === 36) {
-							positionLock = 0;
-						}
-						spine.css({"position":"fixed","top":positionLock+"px"});
-						self.nav_state.positionLock=positionLock;
+					if ( e.which === 35 ) {
+						positionLock = height_dif;
+					} else if ( e.which === 36 ) {
+						positionLock = 0;
 					}
-				});
-			} else {
-				$("#scroll").on("focus",function(){
-					$(document).trigger("touchend");
-				});
-			}
+
+					spine.css( { "position" : "fixed", "top" : positionLock + "px" } );
+					self.nav_state.positionLock = positionLock;
+				}
+			} );
 
 			// Apply the `.skimmed` class to the Spine on non mobile views after 148px.
 			if ( ! $.is_iOS() && ! $.is_Android() ) {

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -299,11 +299,12 @@
 				spine.toggleClass("unshelved shelved");
 			});
 
-			main.on("click swipeleft", function() {
-				if ( spine.is(".unshelved") ) {
-					spine.toggleClass("shelved unshelved");
+			// Close the mobile Spine navigation when a click occurs outside of the Spine.
+			main.on( "click swipeleft", function() {
+				if ( spine.hasClass( "unshelved" ) ) {
+					spine.toggleClass( "shelved unshelved" );
 				}
-			});
+			} );
 
 			// Fixed/Sticky Horizontal Header
 			$( document ).on( "scroll touchmove", function() {

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -358,6 +358,11 @@
 		apply_nav_func: function(self) {
 			var spine, glue, main, top, bottom, scroll_top, positionLock, scroll_dif, spine_ht, viewport_ht, glue_ht, height_dif;
 
+			// Disable extended nav positioning for mobile devices.
+			if ( $.is_Android() || $.is_iOS() ) {
+				return;
+			}
+
 			spine = self._get_globals("spine").refresh();
 			glue = self._get_globals("glue").refresh();
 			main = self._get_globals("main").refresh();

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -338,7 +338,7 @@
 			}
 
 			// Apply the `.skimmed` class to the Spine on non mobile views after 148px.
-			if ( ! $.is_iOS() && !$.is_Android() ) {
+			if ( ! $.is_iOS() && ! $.is_Android() ) {
 				$( document ).scroll( function() {
 					var top;
 					top = $( document ).scrollTop();

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -297,12 +297,14 @@
 			$("header button").on("click",function(e) {
 				e.preventDefault();
 				spine.toggleClass("unshelved shelved");
+				$( "html" ).addClass( "spine-mobile-nav" );
 			});
 
 			// Close the mobile Spine navigation when a click occurs outside of the Spine.
 			main.on( "click swipeleft", function() {
 				if ( spine.hasClass( "unshelved" ) ) {
 					spine.toggleClass( "shelved unshelved" );
+					$( "html" ).removeClass( "spine-mobile-nav" );
 				}
 			} );
 

--- a/styles/sass/_respond.scss
+++ b/styles/sass/_respond.scss
@@ -48,9 +48,12 @@
 /* Tablets (iPad) then iPads (portrait, not landscape) */
 
 @media screen
-	and ( max-width : 989px )
+	and ( max-width : 989px ) {
 
-	{
+  .spine-mobile-nav body {
+    position: fixed;
+    overflow: hidden;
+  }
 
 #binder {
 	width: 792px;

--- a/styles/sass/_respond.scss
+++ b/styles/sass/_respond.scss
@@ -15,168 +15,152 @@
 	position: absolute;
 	width: 900px;
 	height: 15px;
-	box-shadow: 0px 4px 10px -6px rgba(0,0,0,0.5);
+	box-shadow: 0 4px 10px -6px rgba(0,0,0,0.5);
 	-webkit-transition: box-shadow 0.1s ease-in-out;
 	transition: box-shadow 0.1s ease-in-out;
 	top: 35px;
 	left: 298px;
 	display: block;
 	z-index: 1;
-	}
-
+}
 
 /* ## LARGE (after first break) */
-
-@media screen
-	and ( max-width : 1187px )
-
-	{
-
-/* ### Large Grid */
-
-@include grid-large-controls;
-
-	}
+@media screen and ( max-width : 1187px ) {
+	/* ### Large Grid */
+	@include grid-large-controls;
+}
 
 .max-1188 .rebound,
 .max-1188 .row.rebound {
 	width: 792px;
-	}
+}
 
 /* ## MEDIUM (after first break) */
-
 /* Tablets (iPad) then iPads (portrait, not landscape) */
+@media screen and ( max-width : 989px ) {
 
-@media screen
-	and ( max-width : 989px ) {
-
-  .spine-mobile-nav body {
-    position: fixed;
-    overflow: hidden;
-  }
-
-#binder {
-	width: 792px;
-	}
-#binder main {
-	margin-left: 0px;
-	margin-top: 50px;
+	.spine-mobile-nav body {
+		position: fixed;
+		overflow: hidden;
 	}
 
-#binder.fluid {
-	width: 100%;
-	}
-#binder.fluid main {
-	width: auto;
-	margin-left: 198px;
-	margin-top: 0px;
+	#binder {
+		width: 792px;
 	}
 
-.spineless.fixed main,
-.spineless.hybrid main,
-.spineless .fixed main,
-.spineless .hybrid main {
-	margin-left: 0px;
-	width: 792px;
+	#binder main {
+		margin-left: 0;
+		margin-top: 50px;
 	}
 
-.spineless.fluid main,
-.spineless .fluid main {
-	margin-left: 0px;
-	}
-#binder.fluid main {
-	margin-top: 0px;
+	#binder.fluid {
+		width: 100%;
 	}
 
-.fluid .row.rebound,
-.fluid .verso .rebound,
-.fluid .recto .rebound,
-.fluid .recto.verso .rebound {
-	width: 100%;
+	#binder.fluid main {
+		width: auto;
+		margin-left: 198px;
+		margin-top: 0;
 	}
 
-.fluid .recto.verso .rebound,
-.fluid .verso .rebound {
-	border-left: 198px transparent solid;
+	.spineless.fixed main,
+	.spineless.hybrid main,
+	.spineless .fixed main,
+	.spineless .hybrid main {
+		margin-left: 0;
+		width: 792px;
 	}
 
-.verso .rebound {
-	border-left: 0px transparent solid;
-	margin-left: auto;
-	margin-right: 0px;
+	.spineless.fluid main,
+	.spineless .fluid main {
+		margin-left: 0;
 	}
 
-.recto.verso .rebound {
-	border-left: 0px transparent solid;
-	margin-left: auto;
-	margin-right: auto;
+	#binder.fluid main {
+		margin-top: 0;
 	}
 
-.spineless .fluid .verso .rebound,
-.spineless .fluid .recto.verso .rebound {
-	border-left: 0px transparent solid;
+	.fluid .row.rebound,
+	.fluid .verso .rebound,
+	.fluid .recto .rebound,
+	.fluid .recto.verso .rebound {
+		width: 100%;
 	}
 
-/* Shelving */
+	.fluid .recto.verso .rebound,
+	.fluid .verso .rebound {
+		border-left: 198px transparent solid;
+	}
 
-.hybrid #wsu-signature,
-.fixed #wsu-signature {
-	background-position: center 12px;
-	background-size: auto 30px;
-	height: 49px;
+	.verso .rebound {
+		border-left: 0 transparent solid;
+		margin-left: auto;
+		margin-right: 0;
+	}
+
+	.recto.verso .rebound {
+		border-left: 0 transparent solid;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.spineless .fluid .verso .rebound,
+	.spineless .fluid .recto.verso .rebound {
+		border-left: 0 transparent solid;
+	}
+
+	/* Shelving */
+	.hybrid #wsu-signature,
+	.fixed #wsu-signature {
+		background-position: center 12px;
+		background-size: auto 30px;
+		height: 49px;
 	}
 	
-#binder:not(.fluid) {
-
-	@include shelved;
-
+	#binder:not(.fluid) {
+		@include shelved;
 	}
 
-/* Layout Adjustments */
-
-.hybrid {
-
-	@include layouts-percents;
-
+	/* Layout Adjustments */
+	.hybrid {
+		@include layouts-percents;
 	}
 
-/* Adjust Search */
-.spine-search input[type="text"] {
-	padding-right: 18px;
-	}
-.spine-search button {
-	right: 10px;
+	/* Adjust Search */
+	.spine-search input[type="text"] {
+		padding-right: 18px;
 	}
 
-/* Header Colors and Signatures */
+	.spine-search button {
+		right: 10px;
+	}
 
-#binder:not(.fluid) #spine {
-	@each $spine-color, $color in $spine-colors {
-		&.#{""+$spine-color} header { background-color: $color; }
+	/* Header Colors and Signatures */
+	#binder:not(.fluid) #spine {
+		@each $spine-color, $color in $spine-colors {
+			&.#{""+$spine-color} header { background-color: $color; }
 		}
 	}
 
-/* Signature */
+	/* Signature */
 
-nav a.external:after {
-	font-family: "Spine-Icons";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	position: absolute;
-	margin-left: 3px;
-	content: "\21AA";
+	nav a.external:after {
+		font-family: "Spine-Icons";
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		position: absolute;
+		margin-left: 3px;
+		content: "\21AA";
 	}
 
-/* Grid Medium */
-@include grid-medium-controls;
+	/* Grid Medium */
+	@include grid-medium-controls;
 
-@include header-colors;
+	@include header-colors;
 
-@include signatures('horizontal','.fixed ');
-@include signatures('horizontal','.hybrid ');
-
-	}
-
+	@include signatures('horizontal','.fixed ');
+	@include signatures('horizontal','.hybrid ');
+}
 
 /* SMALL (max 791px)
 ------------------------------------------ */

--- a/styles/sass/_respond.scss
+++ b/styles/sass/_respond.scss
@@ -16,8 +16,8 @@
 	width: 900px;
 	height: 15px;
 	box-shadow: 0 4px 10px -6px rgba(0,0,0,0.5);
-	-webkit-transition: box-shadow 0.1s ease-in-out;
-	transition: box-shadow 0.1s ease-in-out;
+	-webkit-transition: box-shadow 200ms ease;
+	transition: box-shadow 200ms ease;
 	top: 35px;
 	left: 298px;
 	display: block;

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -42,10 +42,6 @@
 			height: 50px;
 		}
 
-		.spine-actions {
-			padding-top: 50px;
-		}
-
 		#wsu-actions section {
 			width: 298px;
 		}

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -119,9 +119,9 @@
 		#scroll {
 			overflow-y: scroll;
 			-webkit-overflow-scrolling: touch;
-			position: absolute;
-			top: 0px;
-			bottom: 0px;
+			position: fixed;
+			top: 50px;
+			bottom: 0;
 			width: 298px;
 			z-index: 99165;
 

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -1,8 +1,7 @@
 @charset "UTF-8";
+
 @mixin shelved {
-
 	#spine {
-
 		width: 298px;
 		min-height: 100%;
 		left: -298px;
@@ -13,64 +12,71 @@
 		#glue {
 			width: 298px;
 			margin-top: 50px;
-			}
+		}
+
 		#glue:before {
 			left: -702px;
 			width: 1000px;
-			}
+		}
 
 		button#shelve {
 			display: block;
-			}
+		}
+
 		&.shelved {
 			-webkit-transition: left 0.2s ease-in-out;
 			transition: left 0.4s ease-in-out;
 			left: -500px;
-			}
+		}
+
 		&.unshelved {
 			-webkit-transition: left 0.2s ease-in-out;
 			left: 0;
-			}
+		}
+
 		header {
 			top: 0;
 			left: 0;
 			width: 100%;
 			position: fixed;
 			height: 50px;
-			}
+		}
+
 		.spine-actions {
 			padding-top: 50px;
-			}
+		}
+
 		#wsu-actions section {
 			width: 298px;
-			}
+		}
+
 		.spine-navigation {
 			padding-bottom: 100px;
-			}
+		}
+
 		nav ul li {
 			line-height: 1.5em;
-			}
+		}
+
 		nav ul li.parent > a:after,
 		nav ul li.parent.opened > a:after {
 			display: block;
-			}
-		footer {
-			width: 242px; // 298px - ( ( 1.75em x 16px ) x 2 = 56 )
-			}
-
 		}
 
+		footer {
+			width: 242px; // 298px - ( ( 1.75em x 16px ) x 2 = 56 )
+		}
 	}
+}
 
 @mixin unshelved {
-
 	#spine {
-
 		left: auto;
 
 		button#shelve {
 			display: none;
-			}
+		}
+
 		&.unshelved,
 		&.shelved,
 		&.skimmed header,
@@ -78,42 +84,41 @@
 			box-shadow: none;
 			-webkit-transition: none;
 			left: auto;
-			}
+		}
+
 		#glue header {
 			top: 0;
 			left: 0;
 			position: relative;
 			height: 198px;
-			}
+		}
+
 		#wsu-actions {
-			padding-top: 0px;
-			}
+			padding-top: 0;
+		}
+
 		#wsu-actions section {
 			width: 298px;
-			}
 		}
+	}
 
 	.row.side-right .column {
 		width: 100%;
-		}
+	}
 
 	#wsu-signature {
 		background-position: center;
 		background-size: 180px auto;
 		height: 197px;
-		}
-
 	}
+}
 
 @mixin navscroll {
-
     #spine.unshelved {
-
-	    /*top: 0px !important;*/
 	    min-height: 0 !important;
 
 		#wsu-actions {
-			padding-top: 0px !important;
+			padding-top: 0 !important;
 		}
 
 		#scroll {
@@ -137,50 +142,27 @@
 	}
 }
 
-
-
-
 @mixin unshelved-ios {
+	@media only screen and (max-device-width: 480px) and (orientation:portrait),
+		only screen and (max-device-width: 480px) and (orientation:landscape),
+		only screen	and (device-width: 768px) and (device-height: 1024px) and (orientation:portrait),
+    	only screen and (device-width: 768px) and (device-height: 1024px) and (orientation:landscape) {
 
-@media
+    	#spine.unshelved {
+	    	top: 0 !important;
+	    	min-height: 0 !important;
 
-	only screen
-	and (max-device-width: 480px)
-	and (orientation:portrait),
-
-	only screen
-	and (max-device-width: 480px)
-	and (orientation:landscape),
-
-	only screen
-	and (device-width: 768px)
-	and (device-height: 1024px)
-	and (orientation:portrait),
-
-    only screen
-    and (device-width: 768px)
-    and (device-height: 1024px)
-    and (orientation:landscape)
-
-	{
-
-    #spine.unshelved {
-
-	    top: 0px !important;
-	    min-height: 0 !important;
-
-	    footer {
-		    position: relative !important;
-		    }
-		#wsu-actions {
-			padding-top: 0px !important;
-			}
-		.spine-navigation {
-			padding-bottom: 0px !important;
+			footer {
+				position: relative !important;
 			}
 
+			#wsu-actions {
+				padding-top: 0 !important;
+			}
+
+			.spine-navigation {
+				padding-bottom: 0 !important;
+			}
 		}
-
 	}
-
-	}
+}

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -24,13 +24,14 @@
 		}
 
 		&.shelved {
-			-webkit-transition: left 0.2s ease-in-out;
-			transition: left 0.4s ease-in-out;
+			-webkit-transition: left 300ms ease;
+			transition: left 300ms ease;
 			left: -500px;
 		}
 
 		&.unshelved {
-			-webkit-transition: left 0.2s ease-in-out;
+			-webkit-transition: left 300ms ease;
+			transition: left 300ms ease;
 			left: 0;
 		}
 
@@ -132,7 +133,7 @@
 		}
 
 		#scroll {
-			-webkit-transition: left 0.2s ease-in-out;
+			-webkit-transition: left 300ms ease;
 			left: 0;
 		}
 	}

--- a/styles/sass/vars/_global.scss
+++ b/styles/sass/vars/_global.scss
@@ -196,11 +196,11 @@ $font_domain: '//repo.wsu.edu/spine/develop';
 	}
 
 @mixin header-colors {
-
-	#binder #spine {
-		header { background-color: white; }
-		@each $spine-color, $color in $spine-colors {
-			&.#{""+$spine-color} header { background-color: $color; }
-			}
-		}
-	}
+  #binder #spine {
+    header { background-color: white; }
+    @each $spine-color, $color in $spine-colors {
+      &.#{""+$spine-color} header,
+      &.#{""+$spine-color} #scroll { background-color: $color; }
+    }
+  }
+}

--- a/styles/sass/vars/_global.scss
+++ b/styles/sass/vars/_global.scss
@@ -197,7 +197,8 @@ $font_domain: '//repo.wsu.edu/spine/develop';
 
 @mixin header-colors {
   #binder #spine {
-    header { background-color: white; }
+    header,
+    #scroll { background-color: white; }
     @each $spine-color, $color in $spine-colors {
       &.#{""+$spine-color} header,
       &.#{""+$spine-color} #scroll { background-color: $color; }


### PR DESCRIPTION
* Avoid processing nav positioning Javascript when iOS or Android.
* Convert `#scroll` to a fixed element and style accordingly. This allows Android and iOS to scroll properly even without much of the document sizing JS enabled.
* Only watch and apply `.skimmed` on non-mobile views. No styles work with `.skimmed` when mobile.