### PR TITLE
[PR] Remove zero-units from CSS, adjust csslint to stop on error

### DIFF
--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -35,7 +35,7 @@
 	button {
 		background-color: transparent;
 		border: none;
-		border-radius: 0px;
+		border-radius: 0;
 		text-indent: 120%;
 		white-space: nowrap;
 		overflow: hidden;
@@ -181,9 +181,9 @@ button#shelve::after {
 
 	button:before {
 		font-family: "Spine-Icons";
-		text-indent: 0px;
+		text-indent: 0;
 		position: absolute;
-		left: 0px;	top: 0em; right: 0px; bottom: 0px;
+		left: 0;	top: 0; right: 0; bottom: 0;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
 	}
@@ -208,22 +208,22 @@ button#shelve::after {
 	nav {
 
 		ul {
-			margin: 0px;
-			padding: 0px;
+			margin: 0;
+			padding: 0;
 			}
 		li {
 			list-style: none;
 			}
 		ul li {
 			position: relative;
-			margin: 0px; padding: 0px;
-			border-width: 1px 0px 0px 0px;
+			margin: 0; padding: 0;
+			border-width: 1px 0 0 0;
 			border-style: solid;
 			line-height: 1.1em;
 			}
 		ul li a {
 			display: block;
-			padding: 6px 0px;
+			padding: 6px 0;
 			}
 		ul li li,
 		ul li li:hover {
@@ -374,7 +374,7 @@ button#shelve::after {
 		}
 	a {
 		text-transform: none;
-		padding: .35em 0px;
+		padding: .35em 0;
 		}
 	a i {
 		display: none;
@@ -396,7 +396,7 @@ html.lt-ie9 #spine .spine-actions {
 
 	.spine-actions {
 
-		padding: 0px;
+		padding: 0;
 
 		section {
 			z-index: 99163;
@@ -419,7 +419,7 @@ html.lt-ie9 #spine .spine-actions {
 			}
 
 		ul li {
-			padding: 0px; margin: 0px;
+			padding: 0; margin: 0;
 			list-style: none;
 			}
 
@@ -438,7 +438,7 @@ html.lt-ie9 #spine .spine-actions {
 
 	.spine-actions-tabs {
 
-		padding: 0px;
+		padding: 0;
 		margin-top: 0;
 		margin-right: 1.75em;
 		margin-bottom: 0;
@@ -493,7 +493,7 @@ html.lt-ie9 #spine .spine-actions {
 
 	form {
 		padding: 1em 1.75em 0 1.75em;
-		margin: 0px 0px -1px 0px;
+		margin: 0 0 -1px 0;
 		position: relative;
 		line-height: 1em;
 		}
@@ -644,8 +644,8 @@ html.lt-ie9 #spine .spine-actions {
 #spine-shortcuts *:hover {
 	border: none;
 	background: transparent;
-	padding: 0px;
-	margin: 0px;
+	padding: 0;
+	margin: 0;
 	border-radius: 0;
 	line-height: 1.1em;
 	box-shadow: none;
@@ -655,7 +655,7 @@ html.lt-ie9 #spine .spine-actions {
 
 	li {
 
-		padding: 0px;
+		padding: 0;
 		list-style: none;
 
 		a {
@@ -669,13 +669,13 @@ html.lt-ie9 #spine .spine-actions {
 		a.ui-state-focus {
 			color: white;
 			background-color: #434d53;
-			margin: -1px -1.75em 0px -1.75em;
+			margin: -1px -1.75em 0 -1.75em;
 			padding: .6em 1.75em .6em 1.75em;
 			border-bottom: 2px #434d53 solid;
 			}
 		&:first-child a:hover,
 		&:first-child a.ui-state-focus {
-			margin: 0px -1.75em 0px -1.75em;
+			margin: 0 -1.75em 0 -1.75em;
 			border-bottom: 1px #434d53 solid;
 			}
 		&:first-child a {
@@ -743,7 +743,7 @@ html.lt-ie9 #spine .spine-actions {
 		}
 	.adr {
 		border: none;
-		padding: 0px;
+		padding: 0;
 		}
 	.street-address {
 		border-bottom: none;
@@ -875,7 +875,7 @@ html.lt-ie9 #spine footer {
 			font-size: 1.8em;
 			line-height: .8em;
 			height: 1.2em;
-			padding: .5em 0px !important;
+			padding: .5em 0 !important;
 			display: block;
 			position: relative;
 			text-transform: none;
@@ -967,19 +967,19 @@ html.lt-ie9 #spine footer {
 		display: block;
 		width: 50%;
 		float: left;
-		padding: 10px 0px;
-		margin: 0px;
+		padding: 10px 0;
+		margin: 0;
 		box-sizing: border-box;
 		-webkit-box-sizing: border-box;
 		-moz-box-sizing: border-box;
 		}
 	ul {
-		padding: 0px;
+		padding: 0;
 		}
 	ul li {
 		display: inline-block;
-		margin: 0px;
-		padding: 0px;
+		margin: 0;
+		padding: 0;
 		width: auto;
 		}
 	ul li a {
@@ -1061,8 +1061,8 @@ html.lt-ie9 #spine footer {
 		color: #b6bcbf;
 		display: block;
 		text-align: center;
-		margin: 0px 0px;
-		padding: 6px 0px;
+		margin: 0 0;
+		padding: 6px 0;
 	}
 	.copyright-link a {
 		color: #8b9399;

--- a/styles/sass/_respond.scss
+++ b/styles/sass/_respond.scss
@@ -190,18 +190,18 @@
 #binder main {
 	width: auto;
 	margin-top: 50px;
-	margin-left: 0px;
+	margin-left: 0;
 	}
 #binder.fixed main {
 	width: 396px;
-	margin-left: 0px;
+	margin-left: 0;
 	}
 #binder.hybrid main,
 #binder.fluid main {
 	width: 100%;
 	font-size: 16px;
 	line-height: 26px;
-	margin-left: 0px;
+	margin-left: 0;
 	margin-top: 50px;
 	}
 .row.reverse-at-small .column {
@@ -217,7 +217,7 @@
 
 .fluid .verso .rebound,
 .fluid .recto.verso .rebound {
-	border-left: 0px transparent solid;
+	border-left: 0 transparent solid;
 	}
 
 /* Shelving */
@@ -259,7 +259,7 @@
 	}
 #binder.fixed main {
 	width: 396px;
-	padding-top: 0px;
+	padding-top: 0;
 	margin-left: 298px;
 	}
 
@@ -308,11 +308,11 @@
 
 		width: 396px;
 		min-width: 396px;
-		margin: 0px auto;
+		margin: 0 auto;
 
 		main {
 			margin-top: 50px;
-			margin-left: 0px;
+			margin-left: 0;
 			}
 
 		}
@@ -324,7 +324,7 @@
 
 		main {
 			width: auto;
-			margin-left: 0px;
+			margin-left: 0;
 			}
 
 		}

--- a/styles/sass/respond/_print.scss
+++ b/styles/sass/respond/_print.scss
@@ -4,7 +4,7 @@
 @mixin print-view {
 
 	html.print #binder main {
-		margin-left: 0px;
+		margin-left: 0;
 		}
 	html.print #binder #spine header button#shelve {
 		display: none;
@@ -17,21 +17,21 @@
 		}
 	html.print #spine,
 	html.print #glue {
-		min-height: 0px !important;
-		top: 0px !important;
+		min-height: 0 !important;
+		top: 0 !important;
 		width: 792px;
 		}
 	html.print #glue:before,
 	html.print #spine.bleed #glue:before {
 		width: 792px;
 		height: 50px;
-		left: 0px;
+		left: 0;
 		}
 	html.print #spine {
 		height: 50px;
 		width: 100%;
 		top: 0;
-		margin-left: 0px;
+		margin-left: 0;
 		}
 	html.print main {
 		padding-top: 50px;
@@ -62,7 +62,7 @@
 		width: auto;
 		font-size: 1.4em;
 		line-height: 1em;
-		padding: 0px;
+		padding: 0;
 		}
 	html.print #spine .print-button {
 		display: none;
@@ -72,15 +72,15 @@
 	#spine .print-controls {
 		display: block;
 		z-index: 99164;
-		margin: 0px 10px 0px 0px;
+		margin: 0 10px 0 0;
 		position: absolute;
 		right: 20px;
 		}
 	#spine .print-controls button {
 		display: block;
 		float: left;
-		margin: 0px;
-		text-indent: 0px;
+		margin: 0;
+		text-indent: 0;
 		font-weight: normal;
 		}
 	#spine button#print-invoke,
@@ -92,13 +92,13 @@
 		display: block;
 		}
 	#spine button#print-invoke {
-		border-width: 0px 1px 1px 1px;
-		border-radius: 0px 0px 0px 5px;
+		border-width: 0 1px 1px 1px;
+		border-radius: 0 0 0 5px;
 		padding: 4px 15px 4px 12px;
 		}
 	#spine button#print-cancel {
-		border-width: 0px 1px 1px 0px;
-		border-radius: 0px 0px 5px 0px;
+		border-width: 0 1px 1px 0;
+		border-radius: 0 0 5px 0;
 		padding: 4px 5px 4px 12px;
 		}
 	#spine button#print-invoke:hover,

--- a/styles/sass/skeleton/_asides.scss
+++ b/styles/sass/skeleton/_asides.scss
@@ -3,7 +3,7 @@
 .column .marginalized {
 	position: absolute;
 	box-sizing: border-box;
-	border-width: 0px;
+	border-width: 0;
 	border-style: solid;
 	border-color: #b5babe;
 	padding: 1em 2em;

--- a/styles/sass/skeleton/_boards.scss
+++ b/styles/sass/skeleton/_boards.scss
@@ -14,7 +14,7 @@ body {
 
 #binder {
 	width: 990px;
-	margin: 0px auto;
+	margin: 0 auto;
 	}
 
 main {

--- a/styles/sass/skeleton/_defaults.scss
+++ b/styles/sass/skeleton/_defaults.scss
@@ -11,9 +11,9 @@
 	h6,h5,h4,h3,h2,h1 {
 		margin: 0;
 		line-height: 1.1em;
-		letter-spacing: 0em;
+		letter-spacing: 0;
 		font-weight: bold;
-		padding: .5em 0px .2em 0px;
+		padding: .5em 0 .2em 0;
 		/* Maybe... -webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale; */
 		}
@@ -46,7 +46,7 @@
 	/* ### Lists */
 
 	ul, ol {
-		padding: 0em 2em 1em 2em;
+		padding: 0 2em 1em 2em;
 		}
 	ul ul,
 	ol ol {
@@ -63,7 +63,7 @@
 		}
 
 	p {
-		margin: 0px;
+		margin: 0;
 		padding-bottom: 1em;
 		}
 	p ~ p,
@@ -100,10 +100,10 @@
 		}
 
 	article img[align="right"] {
-		margin: 0px 0px 1em 10px;
+		margin: 0 0 1em 10px;
 		}
 	article img[align="left"] {
-		margin: 0px 10px 1em 0px;
+		margin: 0 10px 1em 0;
 		}
 
 	sup,sub { font-size: .7em; line-height: .7em; }
@@ -119,7 +119,7 @@
 	a:hover { color: #c60c30; }
 	strong,b { font-weight: bold; }
 	em,i { font-style: italic; }
-	hr { border-width: 0px;
+	hr { border-width: 0;
 		border-style: solid;
 		border-color: black;
 		margin: 1em 0;

--- a/styles/sass/skeleton/_forms.scss
+++ b/styles/sass/skeleton/_forms.scss
@@ -16,7 +16,7 @@ input[type="button"] {
 	display: inline-block;
 	text-decoration: none;
 	cursor: pointer;
-	margin-bottom: 0px;
+	margin-bottom: 0;
 	line-height: normal;
 	padding: 0.5em 1em;
 	vertical-align: middle;
@@ -33,7 +33,7 @@ input[type="button"]:focus {
 	color: $gray-dark;
 	background: $gray-er;
 	border-color: $gray-light;
-	border-width: 0px 2px 2px 0px;
+	border-width: 0 2px 2px 0;
 	}
 
 .button:active, .button.active,
@@ -44,7 +44,7 @@ input[type="button"]:active {
 	color: $gray-lighter;
 	border-color: $gray-darkest;
 	background: $gray-dark;
-	border-width: 2px 0px 0px 2px;
+	border-width: 2px 0 0 2px;
 	}
 
 .button.full-width,
@@ -60,10 +60,10 @@ input[type="button"].full-width {
 button.functional,
 button.glassine {
 	border: none;
-	padding: 0px;
-	margin: 0px;
+	padding: 0;
+	margin: 0;
 	background: transparent;
-	border-radius: 0px;
+	border-radius: 0;
 	}
 
 /* Fix for odd Mozilla border & padding issues */
@@ -84,11 +84,11 @@ form,fieldset,input,textarea,legend,label {
 	}
 form {
 	margin-bottom: 5px;
-	padding: 10px 0px;
+	padding: 10px 0;
 	}
 fieldset {
 	margin-bottom: 5px;
-	padding: 0px;
+	padding: 0;
 	}
 input {
 		outline: none;

--- a/styles/sass/skeleton/_headers.scss
+++ b/styles/sass/skeleton/_headers.scss
@@ -25,7 +25,7 @@
 	color: white;
 	line-height: 1em;
 	vertical-align: baseline;
-	margin: 0px;
+	margin: 0;
 	}
 .main-header a,
 .main-header a:hover {

--- a/styles/sass/skeleton/_shorthand.scss
+++ b/styles/sass/skeleton/_shorthand.scss
@@ -19,8 +19,8 @@
 .clear-right-important { clear: right !important; }
 
 /* Important */
-.padless, .padding-0 { padding: 0px !important }
-.marginless, .margin-0 { margin: 0px !important }
+.padless, .padding-0 { padding: 0 !important }
+.marginless, .margin-0 { margin: 0 !important }
 
 .display-block { display: block !important }
 .display-none { display: none !important }

--- a/styles/sass/skeleton/_spineless.scss
+++ b/styles/sass/skeleton/_spineless.scss
@@ -5,12 +5,12 @@
 .spineless.hybrid main,
 .spineless .fixed main,
 .spineless .hybrid main {
-	margin-left: 0px;
+	margin-left: 0;
 	width: 990px;
 	}
 .spineless.fluid main,
 .spineless .fluid main {
-	margin-left: 0px;
+	margin-left: 0;
 	}
 .fluid main {
 	width: auto;

--- a/styles/sass/skeleton/_tables.scss
+++ b/styles/sass/skeleton/_tables.scss
@@ -9,7 +9,7 @@ body table th {
 	}
 body table td,
 body table th {
-	padding: .3em .6em .3em 0em;
+	padding: .3em .6em .3em 0;
 	vertical-align: top;
 	}
 table.stripe td,
@@ -33,7 +33,7 @@ ul.line {
 ul.line li {
 	list-style: none;
 	padding: .3em 0;
-	margin: 0px;
+	margin: 0;
 	}
 ul.line li ~ li {
 	border-top: 1px #d7dadb solid;

--- a/styles/sass/skeleton/_unbind.scss
+++ b/styles/sass/skeleton/_unbind.scss
@@ -13,7 +13,7 @@
 		-moz-box-sizing: border-box;
 		}
 	.verso .rebound {
-		margin-right: 0px;
+		margin-right: 0;
 		margin-left: auto;
 		}
 	.recto.verso .rebound {
@@ -21,7 +21,7 @@
 		margin-right: auto;
 		}
 	.spineless .recto.verso .rebound {
-		border-left-width: 0px;
+		border-left-width: 0;
 		}
 
 	.rebound,

--- a/styles/sass/skeleton/_utilities.scss
+++ b/styles/sass/skeleton/_utilities.scss
@@ -51,7 +51,7 @@ main,
 	width: 100%;
 	}
 .picture-frame {
-	line-height: 0px;
+	line-height: 0;
 	}
 img.grayscale {
     filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#grayscale"); /* Firefox 10+, Firefox on Android */

--- a/styles/sass/spine/_cropped.scss
+++ b/styles/sass/spine/_cropped.scss
@@ -28,7 +28,7 @@
 			}
 
 		&.bleed #glue:before {
-			left: 0px;
+			left: 0;
 			}
 
 		&.shelved button#shelve,
@@ -50,8 +50,8 @@
 				min-height: 0 !important;
 				height: 50px !important;
 				width: 100% !important;
-				padding-top: 0px;
-				padding-bottom: 0px;
+				padding-top: 0;
+				padding-bottom: 0;
 				}
 			#wsu-signature {
 				background-position: center 12px;

--- a/tasks/options/csslint.js
+++ b/tasks/options/csslint.js
@@ -26,7 +26,7 @@ module.exports = {
 			"important": false,                    // 2
 			"empty-rules": false,                  // 2
 			"vendor-prefix": false,                // 2
-			"zero-units": false                    // 2
+			"zero-units": 2
 		}
 	}
 };


### PR DESCRIPTION
This allows us to set the csslint rule for `zero-units` to `2`, which will stop Grunt with an error if any future 0 unit uses are found.