### PR TITLE
Correction to the grunt task `build` to provide the env var

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "build", [
 		"clean",
 		"sass:dev",
+		"env:prod",
 		"concat",
 		"postcss",
 		"csslint",


### PR DESCRIPTION
This correction seems to fix issue raised in [PR] #327 following
https://github.com/washingtonstateuniversity/WSU-spine/pull/327#issuecomment-169796527
.  Local build seemed to be correct