### PR TITLE
[PR] Position `#spine-footer` relatively when nav is longer than window on mobile

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -410,14 +410,14 @@
 				}
 			});
 
+			// Watch for DOM changes and resize the Spine to match.
+			$.observeDOM( glue , function() {
+				self.apply_nav_func( self );
+			} );
+
 			if ( ! self.is_mobile_view() ) {
 				// Fixed/Sticky Horizontal Header
 				$( document ).on( "scroll touchmove", function() {
-					self.apply_nav_func( self );
-				} );
-
-				// Watch for DOM changes and resize the Spine to match.
-				$.observeDOM( glue , function() {
 					self.apply_nav_func( self );
 				} );
 
@@ -460,8 +460,16 @@
 		apply_nav_func: function(self) {
 			var spine, glue, main, top, bottom, scroll_top, positionLock, scroll_dif, spine_ht, viewport_ht, glue_ht, height_dif;
 
-			// Disable extended nav positioning for mobile devices.
 			if ( this.is_mobile_view() ) {
+				// When the navigation area is larger than the window, we position the footer differently.
+				var nav_height = $( ".spine-header" ).height() + $( "#wsu-actions" ).height() + $( "#spine-navigation" ).height();
+				if ( window.innerHeight - nav_height < $( ".spine-footer" ).height() ) {
+					$( "body" ).addClass( "spine-nav-long" );
+				} else {
+					$( "body" ).removeClass( "spine-nav-long" );
+				}
+
+				// Disable extended nav positioning for mobile devices.
 				return;
 			}
 

--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -874,8 +874,17 @@ html.lt-ie9 #spine .spine-actions {
 }
 
 .spine-mobile #spine footer {
-	position: relative;
+	bottom: 69px;
 	width: 242px; // 298px - ( ( 1.75em x 16px ) x 2 = 56 )
+}
+
+.spine-nav-long #spine footer {
+	position: relative;
+	bottom: 0;
+}
+
+.spine-nav-long #spine #scroll {
+	padding-bottom: 69px;
 }
 
 html.lt-ie9 #spine footer {

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -114,10 +114,6 @@
 			bottom: -69px; /* Offset for when iOS address and nav bars hide */
 			width: 298px;
 			z-index: 99165;
-
-			footer {
-				position: relative !important;
-			}
 		}
 	}
 
@@ -137,10 +133,6 @@
 		.spine-mobile-open #spine {
 			top: 0 !important;
 			min-height: 0 !important;
-
-			footer {
-				position: relative !important;
-			}
 
 			#wsu-actions {
 				padding-top: 0 !important;


### PR DESCRIPTION
This provides for a sticky footer when the nav menu is sized differently for different views on mobile. This is already handled for non-mobile views.