### PR TITLE
[PR] Additional work on mobile scrolling behavior

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -186,8 +186,8 @@
 				glue.css( "min-height", viewport_ht );
 				spine.css( "min-height", viewport_ht );
 			} else {
-				glue.css( "min-height", '' );
-				spine.css( "min-height", '' );
+				glue.css( "min-height", "" );
+				spine.css( "min-height", "" );
 			}
 
 			$( document ).trigger( "scroll" );

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -480,6 +480,21 @@
 					}
 				} );
 			}
+
+			/**
+			 * When the navigation area is shorter than the available window, add a margin to the
+			 * Spine footer so that the scroll container becomes active. This avoids issues on
+			 * mobile devices when overflow is not applied.
+			 */
+			if ( self.is_mobile_view() ) {
+				var nav_height = $( ".spine-header" ).height() + $( "#wsu-actions" ).height() + $( "#spine-navigation" ).height();
+				var spine_footer = $( ".spine-footer" );
+				var footer_height = spine_footer.height();
+				if ( window.innerHeight - nav_height >= footer_height ) {
+					var margin = window.innerHeight - nav_height - footer_height;
+					spine_footer.css( "margin-top", margin );
+				}
+			}
 		},
 
 		/**
@@ -492,14 +507,6 @@
 			var spine, glue, main, top, bottom, scroll_top, positionLock, scroll_dif, spine_ht, viewport_ht, glue_ht, height_dif;
 
 			if ( this.is_mobile_view() ) {
-				// When the navigation area is larger than the window, we position the footer differently.
-				var nav_height = $( ".spine-header" ).height() + $( "#wsu-actions" ).height() + $( "#spine-navigation" ).height();
-				if ( window.innerHeight - nav_height < $( ".spine-footer" ).height() ) {
-					$( "body" ).addClass( "spine-nav-long" );
-				} else {
-					$( "body" ).removeClass( "spine-nav-long" );
-				}
-
 				// Disable extended nav positioning for mobile devices.
 				return;
 			}

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -182,12 +182,12 @@
 
 			viewport_ht = $( window ).height();
 
-			if ( $( ".spine-header" ).height() > 50 ) {
+			if ( ! self.is_mobile_view() ) {
 				glue.css( "min-height", viewport_ht );
 				spine.css( "min-height", viewport_ht );
 			} else {
-				glue.css( "min-height", viewport_ht - 50 );
-				spine.css( "min-height", viewport_ht - 50 );
+				glue.css( "min-height", '' );
+				spine.css( "min-height", '' );
 			}
 
 			$( document ).trigger( "scroll" );

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -441,12 +441,12 @@
 				}
 			});
 
-			// Watch for DOM changes and resize the Spine to match.
-			$.observeDOM( glue , function() {
-				self.apply_nav_func( self );
-			} );
-
 			if ( ! self.is_mobile_view() ) {
+				// Watch for DOM changes and resize the Spine to match.
+				$.observeDOM( glue , function() {
+					self.apply_nav_func( self );
+				} );
+
 				// Fixed/Sticky Horizontal Header
 				$( document ).on( "scroll touchmove", function() {
 					self.apply_nav_func( self );
@@ -505,11 +505,6 @@
 		 */
 		apply_nav_func: function(self) {
 			var spine, glue, main, top, bottom, scroll_top, positionLock, scroll_dif, spine_ht, viewport_ht, glue_ht, height_dif;
-
-			if ( this.is_mobile_view() ) {
-				// Disable extended nav positioning for mobile devices.
-				return;
-			}
 
 			spine = self._get_globals("spine").refresh();
 			glue = self._get_globals("glue").refresh();

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -145,7 +145,10 @@
 
 			self.sizing();
 			self.equalizing();
-			self.mainheight();
+
+			if ( self.is_mobile_view() ) {
+				self.mainheight();
+			}
 
 			// Only run function if an unbound element exists
 			if ( $( ".unbound, #binder.broken" ).length ) {

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -401,7 +401,7 @@
 
 					// Prevent scrolling on mobile outside of `#scroll` while the mobile menu is open.
 					$( document ).on( "touchmove touchend touchstart", function( evt ) {
-						if ( $( evt.target ).parents( "#scroll" ).length > 0 ) {
+						if ( $( evt.target ).parents( "#scroll" ).length > 0 || $( evt.target ).is( "#scroll" ) ) {
 							return true;
 						}
 

--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -879,7 +879,7 @@ html.lt-ie9 #spine .spine-actions {
 }
 
 .spine-mobile #spine footer {
-	bottom: 69px;
+	position: relative;
 	width: 242px; // 298px - ( ( 1.75em x 16px ) x 2 = 56 )
 }
 

--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -883,15 +883,6 @@ html.lt-ie9 #spine .spine-actions {
 	width: 242px; // 298px - ( ( 1.75em x 16px ) x 2 = 56 )
 }
 
-.spine-nav-long #spine footer {
-	position: relative;
-	bottom: 0;
-}
-
-.spine-nav-long #spine #scroll {
-	padding-bottom: 69px;
-}
-
 html.lt-ie9 #spine footer {
 	position: relative;
 }

--- a/styles/sass/_respond.scss
+++ b/styles/sass/_respond.scss
@@ -110,12 +110,11 @@
 
 	.spine-mobile #glue {
 		top: 50px;
+		bottom: 0;
 		left: -298px;
 	}
 
 	.spine-mobile-open  #glue {
-		top: 50px;
-		bottom: -69px; /* Offset for when iOS address and nav bars hide */
 		left: 0;
 	}
 

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -91,13 +91,7 @@
 }
 
 @mixin navscroll {
-	.spine-mobile #spine {
-		#scroll {
-			overflow-y: scroll;
-			-webkit-overflow-scrolling: touch; // Add momentum based scrolling to the scroll area.
-		}
-	}
-
+	.spine-mobile-open,
 	.spine-mobile-open body {
 		overflow: hidden;
 	}

--- a/styles/sass/respond/_states.scss
+++ b/styles/sass/respond/_states.scss
@@ -115,7 +115,7 @@
 			position: fixed;
 			left: 0;
 			top: 50px;
-			bottom: -69px; /* Offset for when iOS address and nav bars hide */
+			bottom: 0; /* Offset for when iOS address and nav bars hide */
 			width: 298px;
 			z-index: 99165;
 		}
@@ -123,7 +123,7 @@
 
 	.spine-mobile .spine-animating #spine #scroll {
 		top: 0;
-		bottom: -69px; /* Offset for when iOS address and nav bars hide */
+		bottom: 0; /* Offset for when iOS address and nav bars hide */
 		position: fixed;
 	}
 }


### PR DESCRIPTION
On mobile page views, we need to position `.spine-footer` slightly below the edge of the window so that scrolling behavior acts as expected. We only need to handle this once, on the initial page view, as no menu collapsing happens after that. We can now remove the DOM change trigger for mobile views entirely.