### PR TITLE
[PR] Revisit and clarify JSHint options

### DIFF
--- a/scripts/ui.spine.js
+++ b/scripts/ui.spine.js
@@ -79,7 +79,7 @@
 			return add;
 		};
 
-		while(match = re.exec(html)) {
+		while( ( match = re.exec(html) ) ) {
 			add(html.slice(cursor, match.index))(match[1], true);
 			cursor = match.index + match[0].length;
 		}

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -2,7 +2,6 @@ module.exports = {
 	files: ["Gruntfile.js", "test/*", "tasks/*", "scripts/*.js"],
 	options: {
 		// options here to override JSHint defaults
-		boss: true,
 		curly: true,
 		eqeqeq: true,
 		eqnull: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -5,7 +5,6 @@ module.exports = {
 		curly: true,
 		eqeqeq: true,
 		noarg: true,
-		onevar: true,
 		quotmark: "double",
 		smarttabs: true,
 		trailing: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -6,8 +6,6 @@ module.exports = {
 		eqeqeq: true,
 		noarg: true,
 		quotmark: "double",
-		smarttabs: true,
-		trailing: true,
 		undef: true,
 		unused: true,
 		globals: {

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -4,7 +4,6 @@ module.exports = {
 		// options here to override JSHint defaults
 		curly: true,
 		eqeqeq: true,
-		eqnull: true,
 		expr: true,
 		immed: true,
 		noarg: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -1,20 +1,27 @@
 module.exports = {
-	files: ["Gruntfile.js", "test/*", "tasks/*", "scripts/*.js"],
-	options: {
-		// options here to override JSHint defaults
-		curly: true,
-		eqeqeq: true,
-		noarg: true,
-		quotmark: "double",
-		undef: true,
-		unused: true,
-		globals: {
-			jQuery: true,
-			console: true,
-			module: true,
-			document: true,
-			window:true,
-			MutationObserver:true
+	grunt_files : {
+		src: [ "Gruntfile.js", "tasks/*", "test/sitemap.js" ],
+		options: {
+			curly: true,
+			eqeqeq: true,
+			noarg: true,
+			quotmark: "double",
+			undef: true,
+			unused: true,
+			node: true     // Define globals available when running in Node.
+		}
+	},
+	spine_files : {
+		src: [ "scripts/*.js", "scripts/*.js" ],
+		options: {
+			curly: true,
+			eqeqeq: true,
+			noarg: true,
+			quotmark: "double",
+			undef: true,
+			unused: true,
+			browser: true, // Define globals exposed by modern browsers.
+			jquery: true   // Define globals exposed by jQuery.
 		}
 	}
 };

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -14,9 +14,13 @@ module.exports = {
 	spine_files : {
 		src: [ "scripts/*.js" ],
 		options: {
+			bitwise: true,
 			curly: true,
 			eqeqeq: true,
+			forin: true,
+			freeze: true,
 			noarg: true,
+			nonbsp: true,
 			quotmark: "double",
 			undef: true,
 			unused: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -12,7 +12,7 @@ module.exports = {
 		}
 	},
 	spine_files : {
-		src: [ "scripts/*.js", "scripts/*.js" ],
+		src: [ "scripts/*.js" ],
 		options: {
 			curly: true,
 			eqeqeq: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -4,7 +4,6 @@ module.exports = {
 		// options here to override JSHint defaults
 		curly: true,
 		eqeqeq: true,
-		expr: true,
 		immed: true,
 		noarg: true,
 		onevar: true,

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -4,7 +4,6 @@ module.exports = {
 		// options here to override JSHint defaults
 		curly: true,
 		eqeqeq: true,
-		immed: true,
 		noarg: true,
 		onevar: true,
 		quotmark: "double",


### PR DESCRIPTION
* Split JSHint options into two groups - one for Node/Grunt JS and another for the JavaScript powering the Spine.
* Remove deprecated rules that have been dropped from the JSHint library.
* Add rules to enforce some more strict development.