### PR TITLE
[PR] Calculate Spine action tab heights on window height, not main

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -583,9 +583,9 @@
 				e.preventDefault();
 				wsu_actions.find("*.opened,#wsu-" + tab + ",#wsu-" + tab + "-tab").toggleClass("opened closed");
 
-				action_ht = $("main").outerHeight() - ( $(".spine-header").outerHeight() + $(".wsu-actions-tabs").outerHeight() );
+				action_ht = window.innerHeight - $(".spine-header").outerHeight() - $( "#wsu-actions-tabs" ).outerHeight();
 
-				$(".spine-action.opened").css( "min-height", action_ht );
+				$( ".spine-action.opened" ).css( "min-height", action_ht );
 			});
 		},
 


### PR DESCRIPTION
On page views where `main` was longer than the navigation, the
min height attached to the Spine action when an action was clicked
would be as high as main and create a confusing experience. This
change locks it to the height of the browser, similar to how the
Spine itself is handled.

Fixes #291