### PR TITLE
[PR] Provide explicit `button` types for buttons

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -419,7 +419,7 @@
 		setup_spine: function(){
 			var self, spine, glue, main, viewport_ht, spine_ht, height_dif, positionLock;
 
-			$( "#spine .spine-header" ).prepend( "<button id='shelve' />" );
+			$( "#spine .spine-header" ).prepend( "<button id='shelve' type='button' />" );
 
 			self = this;
 

--- a/scripts/ui.spine.search.js
+++ b/scripts/ui.spine.search.js
@@ -45,7 +45,7 @@
 				tabTemplate: "<section id='wsu-search' class='spine-search spine-action closed'> \
 								<form id='default-search'> \
 									<input name='term' type='text' value='' placeholder='search'> \
-									<button>Submit</button> \
+									<button type='submit'>Submit</button> \
 								</form> \
 								<div id='spine-shortcuts' class='spine-shortcuts'></div> \
 							</section>",


### PR DESCRIPTION
Not all browsers provide the same default for button types, so we should provide explicit defaults ourselves.

* The Spine menu button is a `button` type `button`.
* The Spine search tab submits a search form to search.wsu.edu if clicked and is a `submit` type `button`.

Closes #65.