### PR TITLE
[PR] Apply initial JSCS configuration to match jQuery code standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"grunt-contrib-csslint": "^1.0.0",
 		"grunt-contrib-cssmin": "~1.0.0",
 		"grunt-contrib-jshint": "~1.0.0",
+		"grunt-jscs": "^2.8.0",
 		"grunt-contrib-uglify": "~1.0.0",
 		"grunt-contrib-watch": "~1.0.0",
 		"grunt-env": "~0.4.4",

--- a/scripts/spine.js
+++ b/scripts/spine.js
@@ -1,8 +1,8 @@
-(function($){
+( function( $ ) {
 	"use strict";
-	$(document).ready(function(){
-		$("html").removeClass("no-js").addClass("js");
-		var spineoptions=window.spineoptions||{};
-		$.spine(spineoptions);
-	});
-})(jQuery);
+	$( document ).ready( function() {
+		$( "html" ).removeClass( "no-js" ).addClass( "js" );
+		var spineoptions = window.spineoptions || {};
+		$.spine( spineoptions );
+	} );
+} )( jQuery );

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -4,17 +4,17 @@
  *		jquery.ui.v.js
  */
 /*jshint multistr: true */
-( function($) {
-	$.extend($.ui.spine.prototype, {
+( function( $ ) {
+	$.extend( $.ui.spine.prototype, {
 		/**
 		 * Initialize the Spine framework. Fired automatically in `$.s`, found
 		 * in ui.spine.js.
 		 *
 		 * @param {object} options
 		 */
-		framework_init: function(options) {
-			$.extend(this.framework_options,options);
-			this._set_globals(this.framework_globals);
+		framework_init: function( options ) {
+			$.extend( this.framework_options, options );
+			this._set_globals( this.framework_globals );
 			this.framework_create();
 		},
 
@@ -50,10 +50,10 @@
 		 * Global objects that are part of the Spine framework.
 		 */
 		framework_globals: {
-			spine: $("#spine"),
-			glue: $("#glue"),
-			main: $("main"),
-			wsu_actions: $("#wsu-actions")
+			spine: $( "#spine" ),
+			glue: $( "#glue" ),
+			main: $( "main" ),
+			wsu_actions: $( "#wsu-actions" )
 		},
 
 		/**
@@ -85,6 +85,7 @@
 			if ( window.matchMedia ) {
 				return window.matchMedia( "(max-width: 989px)" ).matches;
 			} else if ( window.styleMedia ) {
+
 				// Fallback for IE 9. IE 8 and below do not support media queries anyway.
 				return window.styleMedia.matchMedium( "(max-width: 989px)" );
 			}
@@ -137,9 +138,9 @@
 			glue = self._get_globals( "glue" ).refresh();
 			main = self._get_globals( "main" ).refresh();
 
-			if ( self.is_mobile_view() && ! self.has_mobile_state() ) {
+			if ( self.is_mobile_view() && !self.has_mobile_state() ) {
 				self.set_spine_state( "mobile" );
-			} else if ( ! self.is_mobile_view() && self.has_mobile_state() ) {
+			} else if ( !self.is_mobile_view() && self.has_mobile_state() ) {
 				self.set_spine_state( "full" );
 			}
 
@@ -182,7 +183,7 @@
 
 			viewport_ht = $( window ).height();
 
-			if ( ! self.is_mobile_view() ) {
+			if ( !self.is_mobile_view() ) {
 				glue.css( "min-height", viewport_ht );
 				spine.css( "min-height", viewport_ht );
 
@@ -199,24 +200,24 @@
 		framework_create: function() {
 			var self, contactHtml, propmap = {}, svg_imgs;
 
-			self = this; // preserve scope.
+			self = this; // Preserve scope.
 
 			// Generate the contact section.
-			if (!$("#wsu-contact").length) {
+			if ( !$( "#wsu-contact" ).length ) {
 				contactHtml = "<section id='wsu-contact' class='spine-contact spine-action closed'>";
 				propmap = {};
 
-				$.each($("[itemtype='http://schema.org/Organization']"),function(){
+				$.each( $( "[itemtype='http://schema.org/Organization']" ), function() {
 					var tar = this;
-					$.each($(tar).find("[itemprop]"),function(i,v){
+					$.each( $( tar ).find( "[itemprop]" ), function( i, v ) {
 						var tmp = {};
-						tmp[$(v).attr("itemprop")] = $(v).attr("content");
-						$.extend(propmap,tmp);
-					});
-					contactHtml += $.runTemplate(self.framework_options.contact_template,propmap);
-				});
+						tmp[ $( v ).attr( "itemprop" ) ] = $( v ).attr( "content" );
+						$.extend( propmap, tmp );
+					} );
+					contactHtml += $.runTemplate( self.framework_options.contact_template, propmap );
+				} );
 				contactHtml += "</section>";
-				self.setup_tabs("contact",contactHtml);
+				self.setup_tabs( "contact", contactHtml );
 			}
 
 			self.setup_nav();
@@ -229,7 +230,7 @@
 			}
 
 			// If SVG is not supported, add a class and replace Spine SVG files with PNG equivalents.
-			if ( ! $.svg_enabled() ) {
+			if ( !$.svg_enabled() ) {
 				$( "html" ).addClass( "nosvg" );
 				svg_imgs = $( "img[src$='.svg']" );
 
@@ -245,7 +246,7 @@
 
 			$( window ).on( "resize orientationchange", function() { self.framework_adjust_on_resize(); } ).trigger( "resize" );
 
-			if ( ! self.is_mobile_view() ) {
+			if ( !self.is_mobile_view() ) {
 				$( document ).trigger( "scroll" );
 			}
 		},
@@ -255,7 +256,7 @@
 		 *
 		 * @param {HTMLelement} jacket
 		 */
-		sizing: function ( jacket ) {
+		sizing: function( jacket ) {
 			var current_width, jacket_classes, px_width, size_intermediate, size_medium, size_large;
 
             jacket = jacket || $( "#jacket" );
@@ -290,33 +291,33 @@
 		/**
 		 * Equalize columns in a layout.
 		 */
-		equalizing: function () {
+		equalizing: function() {
 			var obj;
 
-			if( $(".equalize").length ) {
-				obj = $(".equalize");
-				obj.find(".column").css("min-height","");
+			if ( $( ".equalize" ).length ) {
+				obj = $( ".equalize" );
+				obj.find( ".column" ).css( "min-height", "" );
 
-				$.each(obj,function() {
+				$.each( obj, function() {
 					var tallestBox = 0;
-					$.each($(".column", this), function() {
-						tallestBox = ($(this).outerHeight() > tallestBox) ? $(this).outerHeight() : tallestBox;
-					});
+					$.each( $( ".column", this ), function() {
+						tallestBox = ( $( this ).outerHeight() > tallestBox ) ? $( this ).outerHeight() : tallestBox;
+					} );
 
-					if ( ( $(window).width() <= 792 && !obj.is(".equalize-medium") ) || ( $(window).width() <= 694 && !obj.is(".equalize-small") ) ) {
-						$(".column",this).not(".unequaled").css("min-height","1");
+					if ( ( $( window ).width() <= 792 && !obj.is( ".equalize-medium" ) ) || ( $( window ).width() <= 694 && !obj.is( ".equalize-small" ) ) ) {
+						$( ".column", this ).not( ".unequaled" ).css( "min-height", "1" );
 					} else {
-						$(".column",this).not(".unequaled").css("min-height",tallestBox);
+						$( ".column", this ).not( ".unequaled" ).css( "min-height", tallestBox );
 					}
-					$("section.equalize .column",this).css("min-height","auto");
-				});
+					$( "section.equalize .column", this ).css( "min-height", "auto" );
+				} );
 			}
 		},
 
 		/**
 		 * Apply a minimum height to the `main` element.
 		 */
-		mainheight: function () {
+		mainheight: function() {
 			var main, window_height, main_height;
 
 			main = this._get_globals( "main" ).refresh();
@@ -351,7 +352,7 @@
 		 *
 		 * @param e
 		 */
-		toggle_mobile_nav: function(e) {
+		toggle_mobile_nav: function( e ) {
 			var html, body, spine, glue, transitionEnd;
 
 			if ( typeof e !== "undefined" ) {
@@ -360,8 +361,8 @@
 
 			html = $( "html" );
 			body = $( "body" );
-			spine = $.ui.spine.prototype._get_globals("spine").refresh();
-			glue = $.ui.spine.prototype._get_globals("glue").refresh();
+			spine = $.ui.spine.prototype._get_globals( "spine" ).refresh();
+			glue = $.ui.spine.prototype._get_globals( "glue" ).refresh();
 
 			/* Cross browser support for CSS "transition end" event */
 			transitionEnd = "transitionend webkitTransitionEnd otransitionend MSTransitionEnd";
@@ -416,16 +417,16 @@
 		/**
 		 * Sets up the spine area
 		 */
-		setup_spine: function(){
+		setup_spine: function() {
 			var self, spine, glue, main, viewport_ht, spine_ht, height_dif, positionLock;
 
 			$( "#spine .spine-header" ).prepend( "<button id='shelve' type='button' />" );
 
 			self = this;
 
-			spine = self._get_globals("spine").refresh();
-			glue = self._get_globals("glue").refresh();
-			main = self._get_globals("main").refresh();
+			spine = self._get_globals( "spine" ).refresh();
+			glue = self._get_globals( "glue" ).refresh();
+			main = self._get_globals( "main" ).refresh();
 
 			self.nav_state.scroll_top = 0;
 			self.nav_state.scroll_dif = 0;
@@ -439,11 +440,12 @@
 				if ( $( "html" ).hasClass( "spine-mobile-open" ) ) {
 					self.toggle_mobile_nav( e );
 				}
-			});
+			} );
 
-			if ( ! self.is_mobile_view() ) {
+			if ( !self.is_mobile_view() ) {
+
 				// Watch for DOM changes and resize the Spine to match.
-				$.observeDOM( glue , function() {
+				$.observeDOM( glue, function() {
 					self.apply_nav_func( self );
 				} );
 
@@ -453,9 +455,9 @@
 				} );
 
 				$( document ).keydown( function( e ) {
-					if( e.which === 35 || e.which === 36 ) {
+					if ( e.which === 35 || e.which === 36 ) {
 						viewport_ht	= $( window ).height();
-						spine_ht	= spine[0].scrollHeight;
+						spine_ht	= spine[ 0 ].scrollHeight;
 						height_dif	= viewport_ht - spine_ht;
 
 						if ( e.which === 35 ) {
@@ -464,7 +466,7 @@
 							positionLock = 0;
 						}
 
-						spine.css( { "position" : "fixed", "top" : positionLock + "px" } );
+						spine.css( { "position": "fixed", "top": positionLock + "px" } );
 						self.nav_state.positionLock = positionLock;
 					}
 				} );
@@ -521,7 +523,7 @@
 			self.nav_state.scroll_top = scroll_top;
 
 			// Main should always be at least as high as `#glue`.
-			main.css( { "min-height" : glue_ht } );
+			main.css( { "min-height": glue_ht } );
 
 			/**
 			 * When the content in `main` is larger than the content in `#glue`, maintain a
@@ -554,7 +556,7 @@
 					positionLock = ( -1 * upper_bound );
 				}
 
-				spine.css( { "position" : "fixed", "top" : positionLock + "px" } );
+				spine.css( { "position": "fixed", "top": positionLock + "px" } );
 				self.nav_state.positionLock = positionLock;
 			} else if ( spine.is( "#spine[style]" ) ) {
 				spine.removeAttr( "style" );
@@ -565,23 +567,23 @@
 		 * Process a WSU action tab (mail, sharing, etc...) and setup the
 		 * structure accordingly.
 		 */
-		setup_tabs: function(tab,html) {
+		setup_tabs: function( tab, html ) {
 			var self, wsu_actions, action_ht;
 
 			html = html || "";
 			self = this;
 
-			wsu_actions = self._get_globals("wsu_actions").refresh();
-			wsu_actions.append(html);
+			wsu_actions = self._get_globals( "wsu_actions" ).refresh();
+			wsu_actions.append( html );
 
 			$( "#wsu-" + tab + "-tab button" ).on( "click touchend", function( e ) {
 				e.preventDefault();
-				wsu_actions.find("*.opened,#wsu-" + tab + ",#wsu-" + tab + "-tab").toggleClass("opened closed");
+				wsu_actions.find( "*.opened,#wsu-" + tab + ",#wsu-" + tab + "-tab" ).toggleClass( "opened closed" );
 
-				action_ht = window.innerHeight - $(".spine-header").outerHeight() - $( "#wsu-actions-tabs" ).outerHeight();
+				action_ht = window.innerHeight - $( ".spine-header" ).outerHeight() - $( "#wsu-actions-tabs" ).outerHeight();
 
 				$( ".spine-action.opened" ).css( "min-height", action_ht );
-			});
+			} );
 		},
 
 		/**
@@ -591,7 +593,7 @@
 		 * @param evt
 		 * @private
 		 */
-		_toggle_spine_nav_list : function( evt ) {
+		_toggle_spine_nav_list: function( evt ) {
 			var target = $( evt.target );
 
 			evt.preventDefault();
@@ -627,7 +629,7 @@
 			 */
 			$( "#spine nav li a[class*=current], #spine nav li a[class*=active]" ).parents( "li" ).addClass( "active dogeared" );
 
-			var couplets = $("#spine nav li.parent > a");
+			var couplets = $( "#spine nav li.parent > a" );
 
 			/**
 			 * Walk through each of the anchor elements in the navigation to establish when "Overview"
@@ -635,25 +637,25 @@
 			 */
 			couplets.each( function() {
 				var tar, title, classes, url;
-				tar = $(this);
+				tar = $( this );
 
-				title = ( tar.is("[title]")  ) ? tar.attr("title") : "Overview";
-				title = ( tar.is("[data-overview]") ) ?tar.data("overview") : title;
-				title = title.length > 0 ? title : "Overview"; // this is just triple checking that a value made it here.
+				title = ( tar.is( "[title]" )  ) ? tar.attr( "title" ) : "Overview";
+				title = ( tar.is( "[data-overview]" ) ) ? tar.data( "overview" ) : title;
+				title = title.length > 0 ? title : "Overview"; // This is just triple checking that a value made it here.
 
 				classes = "overview";
-				if (tar.closest(".parent").is(".dogeared")) {
+				if ( tar.closest( ".parent" ).is( ".dogeared" ) ) {
 					classes += " dogeared";
 				}
 
-				url = tar.attr("href");
+				url = tar.attr( "href" );
 
 				if ( url !== "#" ) {
-					tar.parent("li").children("ul").prepend("<li class='" + classes + "'></li>");
-					tar.clone(true,true).appendTo( tar.parent("li").find("ul .overview:first") );
-					tar.parent("li").find("ul .overview:first a").html(title);
+					tar.parent( "li" ).children( "ul" ).prepend( "<li class='" + classes + "'></li>" );
+					tar.clone( true, true ).appendTo( tar.parent( "li" ).find( "ul .overview:first" ) );
+					tar.parent( "li" ).find( "ul .overview:first a" ).html( title );
 				}
-			});
+			} );
 
 			/**
 			 * Setup navigation events depending on what the screen size is when the document first
@@ -669,14 +671,15 @@
 					$( e.target ).on( "touchmove", function( e ) {
 						$( e.target ).off( "click touchend", $.ui.spine.prototype._toggle_spine_nav_list );
 					} );
-				});
+				} );
 			} else {
+
 				// Disclosure
 				couplets.on( "click", function( e ) {
 					e.preventDefault();
-					$( e.target ).parent("li").siblings().removeClass("opened");
-					$( e.target ).parent("li").toggleClass("opened");
-				});
+					$( e.target ).parent( "li" ).siblings().removeClass( "opened" );
+					$( e.target ).parent( "li" ).toggleClass( "opened" );
+				} );
 
 				// Trigger a scroll action when an anchor link is used.
 				$( "main a[href*='#']:not([href*='://'])" ).on( "mouseup", function() {
@@ -685,18 +688,18 @@
 			}
 
 			// Mark external URLs in the nav menu.
-			$(".spine-navigation a[href^='http']:not([href*='://" + window.location.hostname + "'])").addClass("external");
+			$( ".spine-navigation a[href^='http']:not([href*='://" + window.location.hostname + "'])" ).addClass( "external" );
 		},
 
 		/**
 		 * Handle printing action when selected in the Spine.
 		 */
-		setup_printing: function(){
+		setup_printing: function() {
 			var self, spine, wsu_actions, print_controls;
 
 			self = this;
-			spine = self._get_globals("spine").refresh();
-			wsu_actions = self._get_globals("wsu_actions").refresh();
+			spine = self._get_globals( "spine" ).refresh();
+			wsu_actions = self._get_globals( "wsu_actions" ).refresh();
 
 			// Print & Print View
 			print_controls = "<span class='print-controls'><button id='print-invoke'>Print</button><button id='print-cancel'>Cancel</button></span>";
@@ -706,29 +709,29 @@
 			}
 
 			function print_cancel() {
-				$("html").toggleClass("print");
-				$(".print-controls").remove();
+				$( "html" ).toggleClass( "print" );
+				$( ".print-controls" ).remove();
 			}
 
-			function print(e) {
+			function print( e ) {
 				if ( undefined !== e ) {
 					e.preventDefault();
 				}
-				wsu_actions.find(".opened").toggleClass("opened closed");
-				$("html").toggleClass("print");
-				spine.find("header").prepend(print_controls);
-				$(".unshelved").removeClass("unshelved").addClass("shelved");
-				$("#print-invoke").on("click",function() { window.print(); });
-				$("#print-cancel").on("click",print_cancel);
-				window.setTimeout(function() { printPage(); }, 400);
+				wsu_actions.find( ".opened" ).toggleClass( "opened closed" );
+				$( "html" ).toggleClass( "print" );
+				spine.find( "header" ).prepend( print_controls );
+				$( ".unshelved" ).removeClass( "unshelved" ).addClass( "shelved" );
+				$( "#print-invoke" ).on( "click", function() { window.print(); } );
+				$( "#print-cancel" ).on( "click", print_cancel );
+				window.setTimeout( function() { printPage(); }, 400 );
 			}
-			$("#wsu-print-tab button").click(print);
+			$( "#wsu-print-tab button" ).click( print );
 
 			// Shut a tool section
-			$("button.shut").on( "click touchend", function( e ) {
+			$( "button.shut" ).on( "click touchend", function( e ) {
 				e.preventDefault();
-				wsu_actions.find(".opened").toggleClass("opened closed");
-			});
+				wsu_actions.find( ".opened" ).toggleClass( "opened closed" );
+			} );
 		}
-	});
-} (jQuery) );
+	} );
+}( jQuery ) );

--- a/scripts/ui.spine.js
+++ b/scripts/ui.spine.js
@@ -1,10 +1,10 @@
-/** intended usage is
+/** Intended usage is
 *	$.spine({
 *		"option":"value"
 *	});
 **/
 /*jshint -W054 */
-;(function ( $, window, document, undefined ) {
+;( function( $, window, document, undefined ) {
 	/**
 	 * Strip one or more classes from a class attribute matching a given prefix.
 	 *
@@ -12,17 +12,17 @@
 	 * @param {string} endOrBegin   Omit to match the beginning. Provide a truthy value to only find classes ending with a match.
 	 * @returns {jQuery}
 	 */
-	$.fn.stripClass = function (partialMatch, endOrBegin) {
+	$.fn.stripClass = function( partialMatch, endOrBegin ) {
 		var x;
-		x = new RegExp((!endOrBegin ? "\\b" : "\\S+") + partialMatch + "\\S*", "g");
+		x = new RegExp( ( !endOrBegin ? "\\b" : "\\S+" ) + partialMatch + "\\S*", "g" );
 
 		// http://stackoverflow.com/a/2644364/1037948
-		this.attr("class", function (i, c) {
-			if (!c){
-				return; // protect against no class
+		this.attr( "class", function( i, c ) {
+			if ( !c ) {
+				return; // Protect against no class
 			}
-			return c.replace(x, "");
-		});
+			return c.replace( x, "" );
+		} );
 		return this;
 	};
 
@@ -37,17 +37,17 @@
 	 */
 	$.fn.refresh = function() {
 		var elems;
-		elems = $(this.selector);
-		this.splice(0, this.length);
+		elems = $( this.selector );
+		this.splice( 0, this.length );
 
 		try {
-			this.push.apply(this, elems);
+			this.push.apply( this, elems );
 		}
-		catch(err) {
-			if($(this.selector).html()!==""){
-				return $(this.selector);
-			}else{
-				return $("<div>");
+		catch ( err ) {
+			if ( $( this.selector ).html() !== "" ) {
+				return $( this.selector );
+			}else {
+				return $( "<div>" );
 			}
 		}
 		return this;
@@ -62,7 +62,7 @@
 	 * @param {Object} options
 	 * @returns {*}
 	 */
-	$.runTemplate = function(html, options) {
+	$.runTemplate = function( html, options ) {
 		var re, add, match, cursor, code, reExp, result;
 
 		re = /<%(.+?)%>/g;
@@ -70,23 +70,23 @@
 		code = "var r=[];\n";
 		cursor = 0;
 
-		add = function(line, js) {
-			if(js){
-				code += line.match(reExp) ? line + "\n" : "r.push(" + line + ");\n";
-			}else{
-				code += line !== "" ? "r.push('" + line.replace(/'/g, "\"") + "');\n" : "";
+		add = function( line, js ) {
+			if ( js ) {
+				code += line.match( reExp ) ? line + "\n" : "r.push(" + line + ");\n";
+			}else {
+				code += line !== "" ? "r.push('" + line.replace( /'/g, "\"" ) + "');\n" : "";
 			}
 			return add;
 		};
 
-		while( ( match = re.exec(html) ) ) {
-			add(html.slice(cursor, match.index))(match[1], true);
-			cursor = match.index + match[0].length;
+		while ( ( match = re.exec( html ) ) ) {
+			add( html.slice( cursor, match.index ) )( match[ 1 ], true );
+			cursor = match.index + match[ 0 ].length;
 		}
 
-		add(html.substr(cursor, html.length - cursor));
-		code = (code + "return r.join('');").replace(/[\r\t\n]/g, "");
-		result = new Function(code).apply(options);
+		add( html.substr( cursor, html.length - cursor ) );
+		code = ( code + "return r.join('');" ).replace( /[\r\t\n]/g, "" );
+		result = new Function( code ).apply( options );
 
 		return result;
 	};
@@ -99,7 +99,7 @@
 	 * @returns {*}
 	 */
 	$.whenAll = function() {
-		return $.when.apply($, arguments);
+		return $.when.apply( $, arguments );
 	};
 
 	/**
@@ -108,7 +108,7 @@
 	 * @returns {boolean}
 	 */
 	$.is_iOS = function() {
-		return ( window.navigator.userAgent.match(/(iPad|iPhone|iPod)/ig) ? true : false );
+		return ( window.navigator.userAgent.match( /(iPad|iPhone|iPod)/ig ) ? true : false );
 	};
 
 	/**
@@ -117,7 +117,7 @@
 	 * @returns {boolean}
 	 */
 	$.is_Android = function() {
-		return ( window.navigator.userAgent.match(/(Android)/ig) ? true : false );
+		return ( window.navigator.userAgent.match( /(Android)/ig ) ? true : false );
 	};
 
 	/**
@@ -126,7 +126,7 @@
 	 * @returns {boolean}
 	 */
 	$.svg_enabled = function() {
-		return document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1");
+		return document.implementation.hasFeature( "http://www.w3.org/TR/SVG11/feature#Image", "1.1" );
 	};
 
 	/**
@@ -139,62 +139,64 @@
 	 * @param obj
 	 * @param callback
 	 */
-	$.observeDOM = function(obj,callback) {
+	$.observeDOM = function( obj, callback ) {
 		var config, mutationObserver;
 
-		if (window.MutationObserver) {
+		if ( window.MutationObserver ) {
 			config = {
 				childList: true,
 				attributes: true,
 				subtree: true,
 				attributeOldValue: true,
-				attributeFilter: ["class", "style"]
+				attributeFilter: [ "class", "style" ]
 			};
 
-			mutationObserver = new MutationObserver(function(mutationRecords) {
+			mutationObserver = new MutationObserver( function( mutationRecords ) {
 				var fire_callback = false; // Assume no callback is needed.
 
-				$.each(mutationRecords, function(index, mutationRecord) {
-					if (mutationRecord.type === "childList") {
-						if (mutationRecord.addedNodes.length > 0) {
+				$.each( mutationRecords, function( index, mutationRecord ) {
+					if ( mutationRecord.type === "childList" ) {
+						if ( mutationRecord.addedNodes.length > 0 ) {
 							fire_callback = true;
-						} else if (mutationRecord.removedNodes.length > 0) {
+						} else if ( mutationRecord.removedNodes.length > 0 ) {
 							fire_callback = true;
 						}
-					} else if (mutationRecord.type === "attributes") {
-						if (mutationRecord.attributeName === "class") {
+					} else if ( mutationRecord.type === "attributes" ) {
+						if ( mutationRecord.attributeName === "class" ) {
 							fire_callback = true;
 						}
 					}
-				});
+				} );
 
 				// If one of our matched mutations has been observed, fire the callback.
 				if ( fire_callback ) {
 					callback();
 				}
-			});
-			mutationObserver.observe(obj[0], config);
+			} );
+			mutationObserver.observe( obj[ 0 ], config );
 		} else {
-			// Set a fallback function to fire every 200ms and watch for DOM changes.
-			window.setTimeout(function(){
-				var current_obj=obj.refresh();
 
-				if (typeof window.obj_watch === "undefined") {
-					window.obj_watch = current_obj[0];
+			// Set a fallback function to fire every 200ms and watch for DOM changes.
+			window.setTimeout( function() {
+				var current_obj = obj.refresh();
+
+				if ( typeof window.obj_watch === "undefined" ) {
+					window.obj_watch = current_obj[ 0 ];
 				}
 
 				/**
 				 * If the current object does not match the object we're watching, assume
 				 * a DOM mutation has occurred and fire the callback.
 				 */
-				if (window.obj_watch !== current_obj[0]) {
+				if ( window.obj_watch !== current_obj[ 0 ] ) {
 					callback();
 				}
 
-				window.obj_watch = current_obj[0];
+				window.obj_watch = current_obj[ 0 ];
+
 				// Reset observation on the current object.
-				$.observeDOM(current_obj,callback);
-			}, 200);
+				$.observeDOM( current_obj, callback );
+			}, 200 );
 		}
 	};
 
@@ -204,65 +206,65 @@
 	 * @param {string} name
 	 * @param {object} prototype
 	 */
-	$.s = function(name, prototype) {
+	$.s = function( name, prototype ) {
 		var namespace;
 
-		namespace = name.split(".")[0];
-		name = name.split(".")[1];
+		namespace = name.split( "." )[ 0 ];
+		name = name.split( "." )[ 1 ];
 
-		$[namespace] = $[namespace] || {};
+		$[ namespace ] = $[ namespace ] || {};
 
-		$[namespace][name] = function(options, element) {
+		$[ namespace ][ name ] = function( options, element ) {
 			if ( arguments.length ) {
-				this._setup(options, element);
+				this._setup( options, element );
 			}
 		};
 
-		$[namespace][name].prototype = $.extend({
+		$[ namespace ][ name ].prototype = $.extend( {
 			namespace: namespace,
 			pluginName: name
-		}, prototype);
+		}, prototype );
 
-		$.fn[name] = function(context) {
+		$.fn[ name ] = function( context ) {
 			var isMethodCall, context_options, args, returnValue;
 
 			context_options = {};
 
-			if (arguments[1]) {
-				context_options = arguments[1];
+			if ( arguments[ 1 ] ) {
+				context_options = arguments[ 1 ];
 			}
 
 			context = context || {};
 
-			this.options = $.extend({}, context);
+			this.options = $.extend( {}, context );
 
 			isMethodCall = ( typeof context === "string" );
-			args = Array.prototype.slice.call(arguments, 1);
+			args = Array.prototype.slice.call( arguments, 1 );
 			returnValue = this;
 
-			if ( isMethodCall && context.substring(0, 1) === "_" ) {
+			if ( isMethodCall && context.substring( 0, 1 ) === "_" ) {
 				return returnValue;
 			}
 
-			this.each(function() {
+			this.each( function() {
 				var instance;
 
-				instance = $.data(this, name);
+				instance = $.data( this, name );
 
-				if (!instance) {
-					instance = $.data(this, name, new $[namespace][name](context, this));
+				if ( !instance ) {
+					instance = $.data( this, name, new $[ namespace ][ name ]( context, this ) );
 				}
 
-				if (instance[context+"_init"] !== undefined) {
-					if ( instance[context+"_init"] ) {
-						instance[context+"_init"](context_options);
+				if ( instance[ context + "_init" ] !== undefined ) {
+					if ( instance[ context + "_init" ] ) {
+						instance[ context + "_init" ]( context_options );
 					}
 				}
 
-				if (isMethodCall && instance[context] !== undefined ) {
-					returnValue = instance[context].apply(instance, args);
+				if ( isMethodCall && instance[ context ] !== undefined ) {
+					returnValue = instance[ context ].apply( instance, args );
 				}
-			});
+			} );
 			return returnValue;
 		};
 	};
@@ -273,7 +275,7 @@
 	 * Based on a fork of MIT Licensed jquery-ui-map
 	 * See: https://code.google.com/p/jquery-ui-map/source/browse/trunk/ui/jquery.ui.map.js
 	 */
-	$.s("ui.spine", {
+	$.s( "ui.spine", {
 
 		globals: {
 			version: "0.1.0",
@@ -288,10 +290,10 @@
 		 * @param {object}      options
 		 * @param {HTMLElement} element
 		 */
-		_setup: function(options, element) {
+		_setup: function( options, element ) {
 			this.el = element;
 			options = options || {};
-			$.extend(this.options, options, {});
+			$.extend( this.options, options, {} );
 			this._create();
 		},
 
@@ -309,7 +311,7 @@
 				social: []
 			};
 
-			self._call(self.options.callback, self.instance.spine);
+			self._call( self.options.callback, self.instance.spine );
 		},
 
 		/**
@@ -320,13 +322,13 @@
 		 * @param {object} obj     e.g. {'foo':'bar'}
 		 * @param {string} context e.g. 'search', 'social', 'framework'
 		 */
-		_set_globals: function(obj,context) {
+		_set_globals: function( obj, context ) {
 			context = null; // Avoiding jshint error temporarily.
 
-			if (typeof(obj) !== "object") {
+			if ( typeof( obj ) !== "object" ) {
 				return;
 			}
-			$.extend(this.globals,obj);
+			$.extend( this.globals, obj );
 		},
 
 		/**
@@ -336,8 +338,8 @@
 		 * @returns {*}
 		 * @private
 		 */
-		_get_globals: function(context) {
-			return this.globals[context];
+		_get_globals: function( context ) {
+			return this.globals[ context ];
 		},
 
 		/**
@@ -345,9 +347,9 @@
 		 *
 		 * @param {string} context e.g. 'search', 'social', 'framework'
 		 */
-		clear: function(context) {
-			this._c(this.get(context));
-			this.set(context, []);
+		clear: function( context ) {
+			this._c( this.get( context ) );
+			this.set( context, [] );
 
 			return this;
 		},
@@ -357,10 +359,10 @@
 		 *
 		 * @param {object} obj
 		 */
-		_c: function(obj) {
+		_c: function( obj ) {
 			for ( var property in obj ) {
-				if ( obj.hasOwnProperty(property) ) {
-					obj[property] = null;
+				if ( obj.hasOwnProperty( property ) ) {
+					obj[ property ] = null;
 				}
 			}
 		},
@@ -372,15 +374,15 @@
 		 * @param {object} options Contains string property, string value, string operator (AND/OR).
 		 * @param callback:function(search:jObj, isFound:boolean)
 		 */
-		find: function(context, options, callback) {
+		find: function( context, options, callback ) {
 			var obj, isFound, property, value;
-			obj = this.get(context);
-			options.value = $.isArray(options.value) ? options.value : [options.value];
+			obj = this.get( context );
+			options.value = $.isArray( options.value ) ? options.value : [ options.value ];
 			for ( property in obj ) {
-				if ( obj.hasOwnProperty(property) ) {
+				if ( obj.hasOwnProperty( property ) ) {
 					isFound = false;
 					for ( value in options.value ) {
-						if ( $.inArray(options.value[value], obj[property][options.property]) > -1 ) {
+						if ( $.inArray( options.value[ value ], obj[ property ][ options.property ] ) > -1 ) {
 							isFound = true;
 						} else {
 							if ( options.operator && options.operator === "AND" ) {
@@ -389,7 +391,7 @@
 							}
 						}
 					}
-					callback(obj[property], isFound);
+					callback( obj[ property ], isFound );
 				}
 			}
 			return this;
@@ -400,28 +402,28 @@
 		 * @param key:string
 		 * @param value:object(optional)
 		 */
-		get: function(key, value) {
+		get: function( key, value ) {
 			var instance, e, i;
 			instance = this.instance;
-			if ( !instance[key] ) {
-				if ( key.indexOf(">") > -1 ) {
-					e = key.replace(/ /g, "").split(">");
+			if ( !instance[ key ] ) {
+				if ( key.indexOf( ">" ) > -1 ) {
+					e = key.replace( / /g, "" ).split( ">" );
 					for ( i = 0; i < e.length; i++ ) {
-						if ( !instance[e[i]] ) {
-							if (value) {
-								instance[e[i]] = ( (i + 1) < e.length ) ? [] : value;
+						if ( !instance[ e[ i ] ] ) {
+							if ( value ) {
+								instance[ e[ i ] ] = ( ( i + 1 ) < e.length ) ? [] : value;
 							} else {
 								return null;
 							}
 						}
-						instance = instance[e[i]];
+						instance = instance[ e[ i ] ];
 					}
 					return instance;
-				} else if ( value && !instance[key] ) {
-					this.set(key, value);
+				} else if ( value && !instance[ key ] ) {
+					this.set( key, value );
 				}
 			}
-			return instance[key];
+			return instance[ key ];
 		},
 
 		/**
@@ -429,8 +431,8 @@
 		 * @param key:string
 		 * @param value:object
 		 */
-		set: function(key, value) {
-			this.instance[key] = value;
+		set: function( key, value ) {
+			this.instance[ key ] = value;
 			return this;
 		},
 
@@ -438,17 +440,17 @@
 		 * Helper method for unwrapping jQuery/DOM/string elements
 		 * @param obj:string/node/jQuery
 		 */
-		_unwrap: function(obj) {
-			return (!obj) ? null : ( (obj instanceof jQuery) ? obj[0] : ((obj instanceof Object) ? obj : $("#"+obj)[0]) );
+		_unwrap: function( obj ) {
+			return ( !obj ) ? null : ( ( obj instanceof jQuery ) ? obj[ 0 ] : ( ( obj instanceof Object ) ? obj : $( "#" + obj )[ 0 ] ) );
 		},
 
 		/**
 		 * Helper method for calling a function
 		 * @param callback
 		 */
-		_call: function(callback) {
-			if ( callback && $.isFunction(callback) ) {
-				callback.apply(this, Array.prototype.slice.call(arguments, 1));
+		_call: function( callback ) {
+			if ( callback && $.isFunction( callback ) ) {
+				callback.apply( this, Array.prototype.slice.call( arguments, 1 ) );
 			}
 		},
 
@@ -456,18 +458,18 @@
 		 * Destroys spine elements and options.
 		 */
 		clear_spine: function() {
-			this.clear("search").clear("framework").clear("social");
+			this.clear( "search" ).clear( "framework" ).clear( "social" );
 		},
 
 		/**
 		 * Destroys the plugin.
 		 */
-		destroy: function(callback) {
-			this.clear("search").clear("framework").clear("social")._c(this.instance);
-			$.removeData(this.el, this.name);
-			this._call(callback, this);
+		destroy: function( callback ) {
+			this.clear( "search" ).clear( "framework" ).clear( "social" )._c( this.instance );
+			$.removeData( this.el, this.name );
+			this._call( callback, this );
 		}
-	});
+	} );
 
 	/**
 	 * The primary Spine method used to start things up.
@@ -475,25 +477,25 @@
 	 * @param {object} options
 	 * @returns {*}
 	 */
-	$.spine = function(options) {
+	$.spine = function( options ) {
 		var targ;
 
-		targ = this.jquery === undefined ? $("body") : this;
+		targ = this.jquery === undefined ? $( "body" ) : this;
 
-		return $.each(targ,function() {
+		return $.each( targ, function() {
 			var targ;
-			targ = $(this);
+			targ = $( this );
 
 			// Initialize the Spine plugin.
-			targ.spine({});
+			targ.spine( {} );
 
-			options = $.extend( {"framework":{},"search":{},"social":{}}, options );
+			options = $.extend( { "framework":{}, "search":{}, "social":{} }, options );
 
 			// Setup each of the extensions.
-			$.each(options,function(i,v) {
-				targ.spine(i,v);
-			});
-		});
+			$.each( options, function( i, v ) {
+				targ.spine( i, v );
+			} );
+		} );
 	};
 
-})( jQuery, window, document );
+} )( jQuery, window, document );

--- a/scripts/ui.spine.search.js
+++ b/scripts/ui.spine.search.js
@@ -4,14 +4,14 @@
  *		jquery.ui.v.js
  */
 /*jshint multistr: true */
-( function($) {
+( function( $ ) {
 	"use strict";
-	$.extend($.ui.spine.prototype, {
-		search_init: function(options) {
+	$.extend( $.ui.spine.prototype, {
+		search_init: function( options ) {
 			var self;
-			self=this;//hold to preserve scop
-			$.extend(options,self.search_options,options);
-			this._set_globals(this.search_globals);
+			self = this;//Hold to preserve scop
+			$.extend( options, self.search_options, options );
+			this._set_globals( this.search_globals );
 			this.create_search();
 		},
 
@@ -23,7 +23,7 @@
 					nodes: ".spine-navigation",
 					dataType: "html",
 					maxRows: 12,
-					urlSpaces:"%20",
+					urlSpaces:"%20"
 				},
 				atoz:{
 					name:"WSU A to Z index",
@@ -48,7 +48,7 @@
 									<button type='submit'>Submit</button> \
 								</form> \
 								<div id='spine-shortcuts' class='spine-shortcuts'></div> \
-							</section>",
+							</section>"
 			},
 			result:{
 				appendTo: "#spine-shortcuts",
@@ -61,65 +61,65 @@
 			}
 		},
 		search_globals: {
-			wsu_search: $("#wsu-search"),
+			wsu_search: $( "#wsu-search" ),
 			search_input:$( "#wsu-search input[type=text]" )
 		},
-		create_search: function(){
-			var self, wsu_search,tabhtml;
-			self=this;//hold to preserve scop
-			wsu_search = self._get_globals("wsu_search").refresh();
-			if (!wsu_search.length) {
-				tabhtml = $.runTemplate(self.search_options.search.tabTemplate,{});
-			}else{
-				tabhtml = "<section id='wsu-search' class='spine-search spine-action closed'>"+wsu_search.html()+"</section>";
+		create_search: function() {
+			var self, wsu_search, tabhtml;
+			self = this;//Hold to preserve scop
+			wsu_search = self._get_globals( "wsu_search" ).refresh();
+			if ( !wsu_search.length ) {
+				tabhtml = $.runTemplate( self.search_options.search.tabTemplate, {} );
+			}else {
+				tabhtml = "<section id='wsu-search' class='spine-search spine-action closed'>" + wsu_search.html() + "</section>";
 				wsu_search.remove();
 			}
-			this.setup_tabs("search",tabhtml);
+			this.setup_tabs( "search", tabhtml );
 
-			if($("#spine-shortcuts").length<=0){
-				$("#wsu-search").append("<div id='spine-shortcuts' class='spine-shortcuts'></div>");
+			if ( $( "#spine-shortcuts" ).length <= 0 ) {
+				$( "#wsu-search" ).append( "<div id='spine-shortcuts' class='spine-shortcuts'></div>" );
 			}
 
 			$( "#wsu-search-tab button" ).on( "click touchend", function() {
-				self._get_globals("search_input").refresh().focus();
-			});
+				self._get_globals( "search_input" ).refresh().focus();
+			} );
 			this.setup_search();
 		},
 
-		start_search:function(request,callback){
-			var self,term,queries = [];
-			self=this;//hold to preserve scop
+		start_search:function( request, callback ) {
+			var self, term, queries = [];
+			self = this;//Hold to preserve scop
 
-			term = $.trim(request.term);
-			self.search_options.data=[];
-			$.each(self.search_options.providers, function(i,provider){
-				$.ui.autocomplete.prototype.options.termTemplate = (typeof(provider.termTemplate) !== undefined && provider.termTemplate !== "") ? provider.termTemplate : undefined;
-				queries.push(self.run_query(term,provider));
-			});
+			term = $.trim( request.term );
+			self.search_options.data = [];
+			$.each( self.search_options.providers, function( i, provider ) {
+				$.ui.autocomplete.prototype.options.termTemplate = ( typeof( provider.termTemplate ) !== undefined && provider.termTemplate !== "" ) ? provider.termTemplate : undefined;
+				queries.push( self.run_query( term, provider ) );
+			} );
 
-			$.when.apply($, queries).done(
-			function(){
-				$.each(arguments,function(i,v){
-					var data,proData;
-					if(v!==undefined){
-						data=v[0];
-						if(data!==undefined && data.length>0){
-							proData=self.setup_result_obj(term,data);
-							$.merge(self.search_options.data,proData);
+			$.when.apply( $, queries ).done(
+			function() {
+				$.each( arguments, function( i, v ) {
+					var data, proData;
+					if ( v !== undefined ) {
+						data = v[ 0 ];
+						if ( data !== undefined && data.length > 0 ) {
+							proData = self.setup_result_obj( term, data );
+							$.merge( self.search_options.data, proData );
 						}
 					}
-				});
-				self._call(callback, self.search_options.data);
-			});
+				} );
+				self._call( callback, self.search_options.data );
+			} );
 		},
 
-		run_query:function(term,provider){
+		run_query:function( term, provider ) {
 			var self, result = [], tmpObj = [], nodes;
-			self=this;//hold to preserve scop
+			self = this;//Hold to preserve scop
 			result = [];
 
-			if(typeof(provider)!==undefined && typeof(provider.url)!==undefined && provider.nodes===undefined){
-				return $.ajax({
+			if ( typeof( provider ) !== undefined && typeof( provider.url ) !== undefined && provider.nodes === undefined ) {
+				return $.ajax( {
 					url: provider.url,
 					dataType: provider.dataType,
 					data: {
@@ -129,69 +129,69 @@
 						name_startsWith: term,
 						related:self.search_options.search.getRelated
 					}
-				});
-			}else if(typeof(provider)!==undefined && typeof(provider.nodes)!==undefined ){
-				nodes=$(provider.nodes).find("a");
-				$.each(nodes,function(i,v){
-					var obj,text, localtmpObj;
-					obj = $(v);
+				} );
+			}else if ( typeof( provider ) !== undefined && typeof( provider.nodes ) !== undefined ) {
+				nodes = $( provider.nodes ).find( "a" );
+				$.each( nodes, function( i, v ) {
+					var obj, text, localtmpObj;
+					obj = $( v );
 					text = obj.text();
-					if(text.toLowerCase().indexOf(term.toLowerCase())>-1 && obj.attr("href")!=="#"){
+					if ( text.toLowerCase().indexOf( term.toLowerCase() ) > -1 && obj.attr( "href" ) !== "#" ) {
 						localtmpObj = {
 							label:text,
-							value:obj.attr("href"),
+							value:obj.attr( "href" ),
 							related:"false",
 							searchKeywords:""
 						};
-						tmpObj.push(localtmpObj);
+						tmpObj.push( localtmpObj );
 					}
-				});
-				return [tmpObj];
+				} );
+				return [ tmpObj ];
 			}
 		},
 
-		format_result_text:function(term,text,value){
-			var self,termTemplate,regex;
-			self=this;//hold to preserve scope
+		format_result_text:function( term, text, value ) {
+			var self, termTemplate, regex;
+			self = this;//Hold to preserve scope
 
-			termTemplate = "<strong>$1</strong>"; //typeof($.ui.autocomplete.prototype.options.termTemplate)!==undefined ? $.ui.autocomplete.prototype.options.termTemplate : "<strong>$1</strong>";
+			termTemplate = "<strong>$1</strong>"; //Typeof($.ui.autocomplete.prototype.options.termTemplate)!==undefined ? $.ui.autocomplete.prototype.options.termTemplate : "<strong>$1</strong>";
 
-			regex	= "(?![^&;]+;)(?!<[^<>]*)(" + $.ui.autocomplete.escapeRegex(term) + ")(?![^<>]*>)(?![^&;]+;)";
-			text	= "<a href='"+value+"' target='"+self.search_options.result.target+"'>" + text.replace( new RegExp( regex , "gi" ), termTemplate )+"</a>";
+			regex	= "(?![^&;]+;)(?!<[^<>]*)(" + $.ui.autocomplete.escapeRegex( term ) + ")(?![^<>]*>)(?![^&;]+;)";
+			text	= "<a href='" + value + "' target='" + self.search_options.result.target + "'>" + text.replace( new RegExp( regex, "gi" ), termTemplate ) + "</a>";
 
 			return text;
 		},
 
-		setup_result_obj:function(term,data){
+		setup_result_obj:function( term, data ) {
 			var self, matcher;
-			self=this;//hold to preserve scop
-			matcher = new RegExp( $.ui.autocomplete.escapeRegex(term), "i" );
+			self = this;//Hold to preserve scop
+			matcher = new RegExp( $.ui.autocomplete.escapeRegex( term ), "i" );
 			return $.map( data, function( item ) {
-				var text,value,resultObj;
+				var text, value, resultObj;
 				text = item.label;
 				value	= item.value;
-				if ( (item.value && ( !term || matcher.test(text)) || item.related === "true" ) ){
-					text = self.format_result_text(term,text,value);
+				if ( ( item.value && ( !term || matcher.test( text ) ) || item.related === "true" ) ) {
+					text = self.format_result_text( term, text, value );
 					resultObj = {
 						label: text,
 						value: item.value,
-						searchKeywords: item.searchKeywords!==undefined?item.searchKeywords:"false",
-						related: item.related!==undefined?item.related:"false"
+						searchKeywords: item.searchKeywords !== undefined ? item.searchKeywords : "false",
+						related: item.related !== undefined ? item.related : "false"
 					};
 					return resultObj;
 				}
-			});
+			} );
 		},
 
-		setup_search: function (){
-			var self, wsu_search, search_input, focuseitem={};
+		setup_search: function() {
+			var self, wsu_search, search_input, focuseitem = {};
 
-			self=this;//hold to preserve scop
-			wsu_search = self._get_globals("wsu_search").refresh();
-			search_input = self._get_globals("search_input").refresh();
-			focuseitem={};
+			self = this;//Hold to preserve scop
+			wsu_search = self._get_globals( "wsu_search" ).refresh();
+			search_input = self._get_globals( "search_input" ).refresh();
+			focuseitem = {};
 
-			search_input.autosearch({
+			search_input.autosearch( {
 
 				appendTo:			self.search_options.result.appendTo,
 				showRelated:		self.search_options.result.showRelated,
@@ -199,63 +199,63 @@
 				minLength:			self.search_options.search.minLength,
 
 				source: function( request, response )  {
-					self.start_search(request,function(data){
-						response(data);
-					});
+					self.start_search( request, function( data ) {
+						response( data );
+					} );
 				},
 				search: function( ) {
-					focuseitem={};
+					focuseitem = {};
 				},
-				select : function( e, ui ) {
+				select: function( e, ui ) {
 					var id, term;
 					id = ui.item.searchKeywords;
-					term =$(ui.item.label).text();
+					term = $( ui.item.label ).text();
 					search_input.val( term );
-					search_input.autosearch("close");
+					search_input.autosearch( "close" );
 					return false;
 				},
-				focus : function( e, ui ) {
-					search_input.val( $(ui.item.label).text() );
-					focuseitem={
+				focus: function( e, ui ) {
+					search_input.val( $( ui.item.label ).text() );
+					focuseitem = {
 						label:ui.item.label
 					};
 					e.preventDefault();
 				},
-				open : function( ) {},
+				open: function( ) {},
 				close: function( e ) {
 					e.preventDefault();
 					return false;
 				}
-			}).data( "autosearch" );
+			} ).data( "autosearch" );
 
 			search_input.on( "keydown", function( e ) {
-				if ( e.keyCode === $.ui.keyCode.TAB && search_input.is($(":focus")) ) {
+				if ( e.keyCode === $.ui.keyCode.TAB && search_input.is( $( ":focus" ) ) ) {
 					e.preventDefault();
 				}
-				if ( e.which === 13){
-					search_input.autosearch("close");
+				if ( e.which === 13 ) {
+					search_input.autosearch( "close" );
 				}
-			});
+			} );
 
-			search_input.off( "click touchend" ).on( "click touchend", function( e ){
+			search_input.off( "click touchend" ).on( "click touchend", function( e ) {
 				e.stopPropagation();
 				e.preventDefault();
-			});
+			} );
 
-			$("#wsu-search form").submit( function() {
-				var scope,site,cx,cof,search_term,search_url;
-				scope = wsu_search.attr("data-default");
-				site = " site:"+window.location.hostname;
+			$( "#wsu-search form" ).submit( function() {
+				var scope, site, cx, cof, search_term, search_url;
+				scope = wsu_search.attr( "data-default" );
+				site = " site:" + window.location.hostname;
 				if ( scope === "wsu.edu" ) {
 					site = "";
 				}
 				cx = "cx=004677039204386950923:xvo7gapmrrg";
 				cof = "cof=FORID%3A11";
 				search_term = search_input.val();
-				search_url = "https://search.wsu.edu/default.aspx?"+cx+"&"+cof+"&q="+search_term+site;
+				search_url = "https://search.wsu.edu/default.aspx?" + cx + "&" + cof + "&q=" + search_term + site;
 				window.location.href = search_url;
 				return false;
-			});
+			} );
 		}
-	});
-} (jQuery) );
+	} );
+}( jQuery ) );

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -4,12 +4,12 @@
 *		jquery.ui.spine.js
 */
 /*jshint multistr: true */
-( function($) {
-	$.extend($.ui.spine.prototype, {
-		social_init: function(options) {
-			$.extend(this.social_options,options);
+( function( $ ) {
+	$.extend( $.ui.spine.prototype, {
+		social_init: function( options ) {
+			$.extend( this.social_options, options );
 
-			this._set_globals(this.social_globals);
+			this._set_globals( this.social_globals );
 			this.social_create();
 		},
 		/**
@@ -29,29 +29,29 @@
 			linkedin_source:"wsu.edu"
 		},
 		social_globals: {
-			share_block: $("#wsu-share")
+			share_block: $( "#wsu-share" )
 		},
-		social_create: function(){
+		social_create: function() {
 			var self, share_block, share_text, current_url, wsu_actions, sharehtml, twitter_text, twitter_handle, linkedin_source;
-			self=this;//hold to preserve scope
-			share_block = self._get_globals("share_block").refresh();
-			if (!share_block.length) {
-				share_text = encodeURIComponent(this.social_options.share_text);
-				twitter_text = encodeURIComponent(this.social_options.twitter_text);
-				twitter_handle = encodeURIComponent(this.social_options.twitter_handle);
-				current_url = self._get_globals("current_url");
-				wsu_actions = self._get_globals("wsu_actions").refresh();
+			self = this;//Hold to preserve scope
+			share_block = self._get_globals( "share_block" ).refresh();
+			if ( !share_block.length ) {
+				share_text = encodeURIComponent( this.social_options.share_text );
+				twitter_text = encodeURIComponent( this.social_options.twitter_text );
+				twitter_handle = encodeURIComponent( this.social_options.twitter_handle );
+				current_url = self._get_globals( "current_url" );
+				wsu_actions = self._get_globals( "wsu_actions" ).refresh();
 				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'> \
 									<ul> \
-										<li class='by-facebook'><a href='https://www.facebook.com/sharer/sharer.php?u="+current_url+"'>Facebook</a></li> \
-										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text="+twitter_text+"&url="+current_url+"&via="+twitter_handle+"' target='_blank'>Twitter</a></li> \
-										<li class='by-googleplus'><a href='https://plus.google.com/share?url="+current_url+"'>Google+</a></li> \
-										<li class='by-linkedin'><a href='https://www.linkedin.com/shareArticle?mini=true&url="+current_url+"&summary="+share_text+"&source="+linkedin_source+"' target='_blank'>Linkedin</a></li> \
-										<li class='by-email'><a href='mailto:?subject="+share_text+"&body="+current_url+"'>Email</a></li> \
+										<li class='by-facebook'><a href='https://www.facebook.com/sharer/sharer.php?u=" + current_url + "'>Facebook</a></li> \
+										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text=" + twitter_text + "&url=" + current_url + "&via=" + twitter_handle + "' target='_blank'>Twitter</a></li> \
+										<li class='by-googleplus'><a href='https://plus.google.com/share?url=" + current_url + "'>Google+</a></li> \
+										<li class='by-linkedin'><a href='https://www.linkedin.com/shareArticle?mini=true&url=" + current_url + "&summary=" + share_text + "&source=" + linkedin_source + "' target='_blank'>Linkedin</a></li> \
+										<li class='by-email'><a href='mailto:?subject=" + share_text + "&body=" + current_url + "'>Email</a></li> \
 									</ul> \
 									</section>";
-				self.setup_tabs("share",sharehtml);
+				self.setup_tabs( "share", sharehtml );
 			} // End Share Generation
 		}
-	});
-} (jQuery) );
+	} );
+}( jQuery ) );

--- a/scripts/ui.spine.social.js
+++ b/scripts/ui.spine.social.js
@@ -41,15 +41,17 @@
 				twitter_handle = encodeURIComponent( this.social_options.twitter_handle );
 				current_url = self._get_globals( "current_url" );
 				wsu_actions = self._get_globals( "wsu_actions" ).refresh();
-				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'> \
-									<ul> \
-										<li class='by-facebook'><a href='https://www.facebook.com/sharer/sharer.php?u=" + current_url + "'>Facebook</a></li> \
-										<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text=" + twitter_text + "&url=" + current_url + "&via=" + twitter_handle + "' target='_blank'>Twitter</a></li> \
-										<li class='by-googleplus'><a href='https://plus.google.com/share?url=" + current_url + "'>Google+</a></li> \
-										<li class='by-linkedin'><a href='https://www.linkedin.com/shareArticle?mini=true&url=" + current_url + "&summary=" + share_text + "&source=" + linkedin_source + "' target='_blank'>Linkedin</a></li> \
-										<li class='by-email'><a href='mailto:?subject=" + share_text + "&body=" + current_url + "'>Email</a></li> \
-									</ul> \
-									</section>";
+
+				sharehtml  = "<section id='wsu-share' class='spine-share spine-action closed'>";
+				sharehtml += "<ul>";
+				sharehtml += "<li class='by-facebook'><a href='https://www.facebook.com/sharer/sharer.php?u=" + current_url + "'>Facebook</a></li>";
+				sharehtml += "<li class='by-twitter'><a href='https://twitter.com/intent/tweet?text=" + twitter_text + "&url=" + current_url + "&via=" + twitter_handle + "' target='_blank'>Twitter</a></li>";
+				sharehtml += "<li class='by-googleplus'><a href='https://plus.google.com/share?url=" + current_url + "'>Google+</a></li>";
+				sharehtml += "<li class='by-linkedin'><a href='https://www.linkedin.com/shareArticle?mini=true&url=" + current_url + "&summary=" + share_text + "&source=" + linkedin_source + "' target='_blank'>Linkedin</a></li>";
+				sharehtml += "<li class='by-email'><a href='mailto:?subject=" + share_text + "&body=" + current_url + "'>Email</a></li>";
+				sharehtml += "</ul>";
+				sharehtml += "</section>";
+
 				self.setup_tabs( "share", sharehtml );
 			} // End Share Generation
 		}

--- a/scripts/wsu_autocomplete.js
+++ b/scripts/wsu_autocomplete.js
@@ -1,5 +1,5 @@
 /*
-	termTemplate:"<strong> <%this.term%> </strong>",
+	TermTemplate:"<strong> <%this.term%> </strong>",
 	this.options.relatedHeader
 
 	termTemplate
@@ -7,28 +7,28 @@
 */
 
 /* jshint onevar: false */
-(function($){
+( function( $ ) {
 	"use strict";
 	$.widget( "ui.autosearch", $.ui.autocomplete, {
 		_renderMenu: function( ul, items ) {
 			var that	= this;
-			var related	= $.grep(items,function(obj){//, item) {
-				return obj.related!=="false";
-			});
-			var unrelated = $.grep(items,function(obj){//, item) {
-				return obj.related==="false";
-			});
-			$.each(unrelated, function(i, item) {
+			var related	= $.grep( items, function( obj ) {//, item) {
+				return obj.related !== "false";
+			} );
+			var unrelated = $.grep( items, function( obj ) {//, item) {
+				return obj.related === "false";
+			} );
+			$.each( unrelated, function( i, item ) {
 				that._renderItemData( ul, item );
-			});
+			} );
 
-			if(this.options.showRelated && related.length){
-				if(this.options.relatedHeader){
+			if ( this.options.showRelated && related.length ) {
+				if ( this.options.relatedHeader ) {
 					that._renderHeader( ul, this.options.relatedHeader );
 				}
-				$.each( related, function(i, item) {
+				$.each( related, function( i, item ) {
 					that._renderItemData( ul, item );
-				});
+				} );
 			}
 		},
 		_renderItemData: function( ul, item ) {
@@ -40,7 +40,7 @@
 			return $( "<li></li>" ).data( "item.autocomplete", item ).append( text ).appendTo( ul );
 		},
 		_renderHeader: function( ul, text ) {
-			return $( "<li></li>" ).append( "<a href=''>"+text+"</a>" ).appendTo( ul );
+			return $( "<li></li>" ).append( "<a href=''>" + text + "</a>" ).appendTo( ul );
 		}
-	});
-})(jQuery);
+	} );
+} )( jQuery );

--- a/tasks/options/jscs.js
+++ b/tasks/options/jscs.js
@@ -3,7 +3,10 @@ module.exports = {
         src: "scripts/*.js",
         options: {
             preset: "jquery",
-            verbose: true, // If you need output with rule names http://jscs.info/overview.html#verbose
+            verbose: true,                                 // Display the rule name with the warning.
+            requireCamelCaseOrUpperCaseIdentifiers: false, // We rely on name_name too much to change them all.
+            maximumLineLength: 250,                        // temporary
+            disallowMultipleLineStrings: false             // temporary
         }
     }
 };

--- a/tasks/options/jscs.js
+++ b/tasks/options/jscs.js
@@ -1,0 +1,9 @@
+module.exports = {
+    spine_files : {
+        src: "scripts/*.js",
+        options: {
+            preset: "jquery",
+            verbose: true, // If you need output with rule names http://jscs.info/overview.html#verbose
+        }
+    }
+};


### PR DESCRIPTION
This provides the ability to do code sniffing with `grunt jscs`. We'll want to hook this up to the development grunt tasks and with continuous integration to help show status.