### PR TITLE
[PR] Re-apply `vertical-align: baseline` to main header sup/sub

### DIFF
--- a/styles/sass/skeleton/_headers.scss
+++ b/styles/sass/skeleton/_headers.scss
@@ -27,6 +27,7 @@
 	color: white;
 	line-height: 1em;
 	margin: 0;
+	vertical-align: baseline; // Only applies when not display block.
 }
 
 .main-header a,

--- a/tasks/options/csslint.js
+++ b/tasks/options/csslint.js
@@ -7,6 +7,7 @@ module.exports = {
 			"compatible-vendor-prefixes": false,   // The library on this is older than autoprefixer.
 			"overqualified-elements": false,       // We have weird uses that will always generate warnings.
 			"known-properties": false,             // Our use of manipulation for touch-action generates an error.
+			"display-property-grouping": false,    // We can't guarantee back-compat with this enabled yet.
 			"ids": false,
 			"regex-selectors": false,              // audit
 			"adjoining-classes": false,
@@ -22,7 +23,6 @@ module.exports = {
 			"duplicate-properties": 2,
 			"star-property-hack": 2,
 			"text-indent": 2,
-			"display-property-grouping": 2,
 			"shorthand": 2,
 			"empty-rules": 2,
 			"vendor-prefix": 2,


### PR DESCRIPTION
This reverts f5098a473862cb. The `vertical-align` property will not apply to a block element, but there are sites using the Spine that have overridden the default `display` property to be `inline` or `inline-block` and now rely on this property being here as a fallback.