### PR TITLE
[PR] Additional Gruntfile cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,14 +14,12 @@ module.exports = function( grunt ) {
 		return object;
 	}
 
-	var pkg,setbase,config;
+	var pkg, config;
 
 	pkg = grunt.file.readJSON( "package.json" );
-	setbase = grunt.option( "setbase" ) || pkg.build_location + "/" + pkg.build_version + "/";
 
 	config = {
 		pkg: pkg,
-		setbase:setbase,
 		config: {
 			build: "build"
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,6 @@ module.exports = function( grunt ) {
 	grunt.registerTask( "default", [ "jshint" ] );
 
 	grunt.registerTask( "prod", [
-		"env:prod",
 		"build",
 		"build_tests",
 		"copy:main",
@@ -46,7 +45,6 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( "dev", [
 		"jshint",
-		"env:dev",
 		"build",
 		"build_tests",
 		"copy:main",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,7 @@ module.exports = function( grunt ) {
 	] );
 
 	grunt.registerTask( "dev", [
+		"jscs",
 		"jshint",
 		"build",
 		"build_tests",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,21 +34,9 @@ module.exports = function( grunt ) {
 	// Default task(s).
 	grunt.registerTask( "default", [ "dev" ] );
 
-	grunt.registerTask( "prod", [
-		"build",
-		"build_tests",
-		"copy:main",
-		"copy:dev"
-	] );
+	grunt.registerTask( "prod", [ "build" ] );
 
-	grunt.registerTask( "dev", [
-		"jscs",
-		"jshint",
-		"build",
-		"build_tests",
-		"copy:main",
-		"copy:dev"
-	] );
+	grunt.registerTask( "dev", [ "jscs", "jshint", "build" ] );
 
 	grunt.registerTask( "build", [
 		"clean",
@@ -57,6 +45,8 @@ module.exports = function( grunt ) {
 		"postcss",
 		"csslint",
 		"cssmin",
-		"uglify"
+		"uglify",
+		"build_tests",
+		"copy"
 	] );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function( grunt ) {
 	grunt.loadTasks( "tasks" );
 
 	// Default task(s).
-	grunt.registerTask( "default", [ "jshint" ] );
+	grunt.registerTask( "default", [ "dev" ] );
 
 	grunt.registerTask( "prod", [
 		"build",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"grunt-jscs": "^2.8.0",
 		"grunt-contrib-uglify": "~1.0.0",
 		"grunt-contrib-watch": "~1.0.0",
-		"grunt-env": "~0.4.4",
 		"grunt-postcss": "^0.8.0",
 		"grunt-sass": "^1.1.0",
 		"load-grunt-tasks": "~3.4.0",

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -7,11 +7,7 @@ module.exports = {
 			{ expand: true, src: ["marks/*"], dest: "<%= config.build %>/" },
 			{ expand: true, src: ["scripts/*"], dest: "<%= config.build %>/" },
 			{ expand: true, src: ["styles/jqueryui.css", "styles/styles.css"], dest: "<%= config.build %>/" },
-			{ expand: true, src: ["spine.html","spine.min.html","authors.txt","favicon.ico"], dest: "<%= config.build %>/" }
-		]
-	},
-	dev: {
-		files: [
+			{ expand: true, src: ["spine.html","spine.min.html","authors.txt","favicon.ico"], dest: "<%= config.build %>/" },
 			{ flatten: true, expand: true, src: ["test/images/*"], dest: "<%= config.build %>/tests/images/" },
 			{ flatten: true, expand: true, src: ["test/style.css", "test/switches.js"], dest: "<%= config.build %>/tests/" }
 		]

--- a/tasks/options/env.js
+++ b/tasks/options/env.js
@@ -1,8 +1,0 @@
-module.exports = {
-	dev: {
-		NODE_ENV : "DEVELOPMENT"
-	},
-	prod : {
-		NODE_ENV : "PRODUCTION"
-	}
-};


### PR DESCRIPTION
* Remove `grunt-env` from the list of packages, it is unused.
* Remove `setbase` from `Gruntfile.js`, it is unused.
* Run `dev` as the `default` Grunt task.
* Add `jscs` task to the `dev` Grunt task.
* Consolidate task configuration in `Gruntfile.js`.