### PR TITLE
[PR] Only apply box shadow to `#glue` on `.spine-mobile-open`

### DIFF
--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -53,7 +53,7 @@
 	width: 198px;
 }
 
-.spine-mobile #glue {
+.spine-mobile-open #glue {
 	box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
Fixes #372