### PR TITLE
[PR] Remove `spine-mobile-open` from `html` on resize to full

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -103,7 +103,7 @@
 				$( "html" ).removeClass( "spine-full" ).addClass( "ios spine-mobile" );
 				this.setup_nav_scroll();
 			} else {
-				$( "html" ).removeClass( "ios spine-mobile" ).addClass( "spine-full" );
+				$( "html" ).removeClass( "ios spine-mobile spine-mobile-open" ).addClass( "spine-full" );
 				if ( $( "#scroll" ).length ) {
 					$( "#wsu-actions" ).unwrap();
 					$( "#spine header" ).prependTo( "#glue" );


### PR DESCRIPTION
Having this class applied caused the scroll to remain locked even
when the mobile nav was gone.

Fixes #369