### PR TITLE
[PR] Replace wrench with fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
 		"grunt-sass": "^1.1.0",
 		"load-grunt-tasks": "~3.5.0",
 		"nunjucks": "~2.4.0",
-		"wrench": "~1.5.8"
+		"fs-extra": "^0.27.0"
 	}
 }

--- a/tasks/build_tests.js
+++ b/tasks/build_tests.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
 	grunt.registerTask("build_tests", "Set up all test pages", function() {
 		var fs = require("fs");
 		var extend = require("extend");
-		var wrench = require("wrench");
+		var fs = require('fs-extra')
 		var nunjucks = require("nunjucks");
 		var env = nunjucks.configure("test");
 		env.addFilter("indexof", function(str, cmpstr) {
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
 		var sitemap = _sitemap.get_site_obj();
 		var defaults = sitemap.page_defaults;
 
-		wrench.mkdirSyncRecursive("build/tests", 0777);
+		fs.mkdirsSync("build/tests");
 
 		/*
 		 * This will apply defaults and build the nav

--- a/tasks/build_tests.js
+++ b/tasks/build_tests.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
 	grunt.registerTask("build_tests", "Set up all test pages", function() {
 		var fs = require("fs");
 		var extend = require("extend");
-		var fs = require('fs-extra')
+		var fs = require("fs-extra");
 		var nunjucks = require("nunjucks");
 		var env = nunjucks.configure("test");
 		env.addFilter("indexof", function(str, cmpstr) {


### PR DESCRIPTION
Wrench has been deprecated by its maintainer who suggests using
fs-extra instead.

https://www.npmjs.com/package/wrench
https://github.com/jprichardson/node-fs-extra