### PR TITLE
Allow the current section to be toggled open/closed

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -678,7 +678,7 @@
 
 				// When the overview page is active, that area of the navigation should be opened.
 				if ( tar.parent( "li" ).hasClass( "active" ) ) {
-					tar.parent( "li" ).removeClass( "active" ).addClass( "opened" );
+					tar.parents( "li" ).removeClass( "active" ).addClass( "opened dogeared" );
 				}
 			} );
 

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -675,16 +675,21 @@
 				tar.parent( "li" ).children( "ul" ).prepend( "<li class='" + classes + "'></li>" );
 				tar.clone( true, true ).appendTo( tar.parent( "li" ).find( "ul .overview:first" ) );
 				tar.parent( "li" ).find( "ul .overview:first a" ).html( title );
+
+				// When the overview page is active, that area of the navigation should be opened.
+				if ( tar.parent( "li" ).hasClass( "active" ) ) {
+					tar.parent( "li" ).removeClass( "active" ).addClass( "opened" );
+				}
 			} );
 
 			/**
 			 * Account for historical markup in the WSU ecosystem and add the `active` and `dogeared` classes
 			 * to any list items that already have classes similar to `current` or `active`. Also apply the
-			 * `active` and `dogeared` classes to any parent list items of these elements.
+			 * `opened` and `dogeared` classes to any parent list items of these active elements.
 			 *
 			 * `active` and `dogeared` are both used for the styling of active menu items in the navigation.
 			 */
-			$( "#spine nav li[class*=current], #spine nav li[class*=active]" ).addClass( "active dogeared" ).parents( "li" ).addClass( "active dogeared" );
+			$( "#spine nav li[class*=current], #spine nav li[class*=active]" ).addClass( "active dogeared" ).parents( "li" ).addClass( "opened dogeared" );
 
 			/**
 			 * Also look for any anchor elements using a similar method and apply `active` and `dogeared` classes to


### PR DESCRIPTION
When an overview list item is dynamically created, and its parent list item is marked as active, then add `opened` to the parent so that the open/close behavior can be used. Remove `active` as it is not necessary for functionality.

When a non-overview list item is marked as active, make sure its parent has the `opened` class so that it can be open/closed as well.

Fixes #368.