### PR TITLE
[PR] Remove cursor override for active parents

### DIFF
--- a/styles/sass/_column.scss
+++ b/styles/sass/_column.scss
@@ -271,10 +271,6 @@
 			&.active li:last-child a {
 				padding-bottom: 8px;
 			}
-
-			&.active > a:hover {
-				cursor: default;
-			}
 		}
 
 		.active li.parent > a:after,


### PR DESCRIPTION
In previous versions of the Spine, users could not close an active
session so we removed the pointer cursor. This is no longer the case and
pointer should be the default cursor for all anchors.

Fixes #391.