### PR TITLE
[PR] Fix contrast issue for non-focused text inputs

### DIFF
--- a/styles/sass/skeleton/_forms.scss
+++ b/styles/sass/skeleton/_forms.scss
@@ -104,7 +104,7 @@ select {
 	padding: 6px 4px;
 	outline: none;
 	border-radius: 2px;
-	color: #777;
+	color: #767676;
 	margin: 0;
 	background: #fff;
 }


### PR DESCRIPTION
The previous iteration had a contrast of 4.48 to 1, slightly below the WCAG 2.0 AA limit. This adjusts to a 4.54 to 1 contrast ratio.