### PR TITLE
[PR] Introduce a viewport_offset option to the Spine

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -467,8 +467,6 @@
 							positionLock = 0;
 						}
 
-						positionLock = positionLock + this.framework_options.viewport_offset;
-
 						spine.css( { "position": "fixed", "top": positionLock + "px" } );
 						self.nav_state.positionLock = positionLock;
 					}

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -467,6 +467,8 @@
 							positionLock = 0;
 						}
 
+						positionLock = positionLock + this.framework_options.viewport_offset;
+
 						spine.css( { "position": "fixed", "top": positionLock + "px" } );
 						self.nav_state.positionLock = positionLock;
 					}

--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -22,6 +22,7 @@
 		 * Global framework options for the Spine framework.
 		 */
 		framework_options: {
+			viewport_offset: 0,
 			equalizer_filter: ".skip*",
 			contact_template: "<address itemscope itemtype='http://schema.org/Organization' class='hcard'>" +
 								"<% if (typeof(this.department) != 'undefined') { %><div class='organization-unit fn org'>" +
@@ -181,7 +182,7 @@
 				$( ".unbound.verso.recto" ).css( "width", spread );
 			}
 
-			viewport_ht = $( window ).height();
+			viewport_ht = $( window ).height() - this.framework_options.viewport_offset;
 
 			if ( !self.is_mobile_view() ) {
 				glue.css( "min-height", viewport_ht );


### PR DESCRIPTION
This is used when calculating the height of the spine and glue elements to account for a case when a CMS (WordPress) has a fixed bar at the top of the screen.

Setting `spineoptions.framework.viewport_offset` to `32` in that instance will allow the Spine to be resized accordingly.