### PR TITLE
[PR] Account for the viewport offset when calculating the upper bound

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -554,7 +554,7 @@
 				 * from scrolling too far down.
 				 */
 				if ( positionLock < ( -1 * upper_bound ) ) {
-					positionLock = ( -1 * upper_bound );
+					positionLock = ( -1 * upper_bound ) - this.framework_options.viewport_offset;
 				}
 
 				spine.css( { "position": "fixed", "top": positionLock + "px" } );


### PR DESCRIPTION
In cases where a fixed bar is displayed at the top of the page (WordPress), the Spine wasn't able to calculate its proper position.