### PR TITLE
[PR] Increase the specificity of the mobile menu toggle method

### DIFF
--- a/scripts/ui.spine.framework.js
+++ b/scripts/ui.spine.framework.js
@@ -437,7 +437,7 @@
 			self.nav_state.positionLock = 0;
 
 			// The menu button should always trigger a toggle of the mobile navigation.
-			$( "header button" ).on( "click touchend", self.toggle_mobile_nav );
+			$( ".spine-header" ).on( "click touchend", "#shelve", self.toggle_mobile_nav );
 
 			// Tapping anything outside of the Spine should trigger a toggle if the menu is open.
 			main.on( "click", function( e ) {


### PR DESCRIPTION
The selector attached to this was a bit too general, causing the menu to toggle in unexpected (though admittedly outlier) cases.