### PR TITLE
Adjust input styles to better support Firefox focus

### DIFF
--- a/styles/jqueryui.css
+++ b/styles/jqueryui.css
@@ -217,13 +217,6 @@ input.ui-button {
 	margin-right: -.3em;
 }
 
-/* workarounds */
-/* reset extra padding in Firefox, see h5bp.com/l */
-input.ui-button::-moz-focus-inner,
-button.ui-button::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
 .ui-datepicker {
 	width: 17em;
 	padding: .2em .2em 0;

--- a/styles/sass/skeleton/_forms.scss
+++ b/styles/sass/skeleton/_forms.scss
@@ -86,12 +86,7 @@ button.glassine {
 	border-radius: 0;
 }
 
-/* Fix for odd Mozilla border & padding issues */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
+
 
 /* ## FORMS  */
 
@@ -122,12 +117,9 @@ input[type="time"],
 input[type="datalist"],
 textarea,
 select {
-	border: 1px solid #ccc;
 	padding: 6px 4px;
-	border-radius: 2px;
 	color: #717171;
 	margin: 0;
-	background: #fff;
 }
 
 select {


### PR DESCRIPTION
When borders and backgrounds are added to input fields, Firefox apparently stops showing the default focus styles.